### PR TITLE
fixed getActiveRecording

### DIFF
--- a/core/includes/classes/remote.class.php
+++ b/core/includes/classes/remote.class.php
@@ -479,10 +479,10 @@ class Kimai_Remote_Api
 		 */
 		
 		$zef = $this->getBackend()->get_arr_zef($current['zef_in'], $current['zef_out']);
-		$current['zef_knd_ID'] = $zef[0]['pct_kndID'];
-		$current['zef_knd_name'] = $zef[0]['knd_name'];
-		$current['zef_pct_name'] = $zef[0]['pct_name'];
-		$current['zef_evt_name'] = $zef[0]['evt_name'];
+		$current['pct_kndID'] = $zef[0]['pct_kndID'];
+		$current['knd_name'] = $zef[0]['knd_name'];
+		$current['pct_name'] = $zef[0]['pct_name'];
+		$current['evt_name'] = $zef[0]['evt_name'];
 		
 		
 		$result = $this->getSuccessResult(array($current));


### PR DESCRIPTION
for both calls the keys in the responses should be equal.
old responses:
getActiveRecord:
{
  "zef_ID" : "131",
  "zef_in" : "1332515434",
  "zef_knd_ID" : "1",
  "zef_knd_name" : "Testkunde",
  "zef_evtID" : "9",
  "zef_pctID" : "2",
  "zef_out" : "0",
  "zef_time" : "0",
  "zef_pct_name" : "anderesProjekt",
  "zef_evt_name" : "asdasd",
  "zef_servertime" : 1332517188
}
getTimesheet:
{
  "evt_name" : "asdasd",
  "zef_pctID" : "2",
  "usr_alias" : null,
  "pct_ID" : "2",
  "pct_name" : "anderesProjekt",
  "usr_name" : "admin",
  "zef_description" : null,
  "zef_location" : null,
  "zef_in" : "1332515434",
  "knd_name" : "Testkunde",
  "zef_evtID" : "9",
  "zef_comment" : null,
  "zef_cleared" : "0",
  "zef_ID" : "131",
  "zef_billable" : null,
  "zef_comment_type" : "0",
  "pct_comment" : "",
  "zef_trackingnr" : null,
  "zef_budget" : null,
  "pct_kndID" : "1",
  "zef_rate" : "10.00",
  "zef_approved" : null,
  "zef_out" : "0",
  "zef_status" : "open",
  "zef_usrID" : "432355561"
}
