### PR TITLE
fix startRecorder for JSON API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.project
 *.*~
+autoconf.php
+.settings

--- a/core/includes/classes/remote.class.php
+++ b/core/includes/classes/remote.class.php
@@ -259,7 +259,7 @@ class Kimai_Remote_Api
         }
         */
 
-        $result = $this->getBackend()->startRecorder($projectId, $activityId, $uid);
+        $result = $this->getBackend()->startRecorder($projectId, $activityId, $uid, time());
 		if($result) {
 			return $this->getSuccessResult(array());
 		} else {


### PR DESCRIPTION
startRecorder was changed to support an addtional startTime parameter which broke the JSON API
https://github.com/kimai/kimai/commit/acce771379590c8b2dccbb07cdc6315a19665bac
