### PR TITLE
Fixes login-issues via JSON-API

### DIFF
--- a/core/includes/basics.php
+++ b/core/includes/basics.php
@@ -113,6 +113,7 @@ $database = new Kimai_Database_Mysql($kga);
 $database->connect($kga['server_hostname'],$kga['server_database'],$kga['server_username'],$kga['server_password'],$kga['utf8'],$kga['server_type'] );
 Kimai_Registry::setDatabase($database);
 
+global $translations;
 $translations = new Translations($kga);
 if ($kga['language'] != 'en')
   $translations->load($kga['language']);


### PR DESCRIPTION
When using the JSON-API the translations-Object is not set in a global
scope but inside a function and is therefore not globally available.

This Pull-Request adds the global-keyword to the translations-variable to set it globally no matter where the file is included
