### PR TITLE
Database tab in admin panel

### DIFF
--- a/core/extensions/ki_adminpanel/init.php
+++ b/core/extensions/ki_adminpanel/init.php
@@ -184,17 +184,16 @@
     }
 
     $view->showAdvancedTab = $database->global_role_allows($kga['user']['globalRoleID'], 'adminPanel_extension-editAdvanced');
-
-    if ($view->showAdvancedTab)
+    if ($view->showAdvancedTab) {
       $admin['advanced'] = $view->render("advanced.php");
-    
-    if ($kga['show_sensible_data']) {
+    }
+
+    // @FIXME this should not be the "debug" log setting, but a role permission check
+    $view->showDatabase = $kga['show_sensible_data'];
+    if ($view->showDatabase) {
         $admin['database'] = $view->render("database.php");
-    } else {
-        $admin['database'] = "You don't have permission to see this information ...";
     }
 
     $view->admin = $admin;
 
     echo $view->render('main.php');
-?>

--- a/core/extensions/ki_adminpanel/init.php
+++ b/core/extensions/ki_adminpanel/init.php
@@ -186,12 +186,7 @@
     $view->showAdvancedTab = $database->global_role_allows($kga['user']['globalRoleID'], 'adminPanel_extension-editAdvanced');
     if ($view->showAdvancedTab) {
       $admin['advanced'] = $view->render("advanced.php");
-    }
-
-    // @FIXME this should not be the "debug" log setting, but a role permission check
-    $view->showDatabase = $kga['show_sensible_data'];
-    if ($view->showDatabase) {
-        $admin['database'] = $view->render("database.php");
+      $admin['database'] = $view->render("database.php");
     }
 
     $view->admin = $admin;

--- a/core/extensions/ki_adminpanel/templates/scripts/main.php
+++ b/core/extensions/ki_adminpanel/templates/scripts/main.php
@@ -117,9 +117,8 @@
 		</div>
 	</div>
 	
-
-<!-- advanced -->
 <?php if ($this->showAdvancedTab): ?>
+    <!-- advanced -->
 	<div id="adminPanel_extension_sub4">
 		<div class="adminPanel_extension_panel_header">
 			<a onClick="adminPanel_extension_subtab_expand(4)">
@@ -133,7 +132,8 @@
 	</div>
 <?php endif; ?>
 
-<!-- DB -->
+<?php if ($this->showDatabase): ?>
+    <!-- DB -->
     <div id="adminPanel_extension_sub5">
         <div class="adminPanel_extension_panel_header">
             <a onClick="adminPanel_extension_subtab_expand(5)">
@@ -145,5 +145,6 @@
             <?php echo $this->admin['database']?>
         </div>
     </div>
+<?php endif; ?>
 
 </div>

--- a/core/extensions/ki_adminpanel/templates/scripts/main.php
+++ b/core/extensions/ki_adminpanel/templates/scripts/main.php
@@ -132,7 +132,7 @@
 	</div>
 <?php endif; ?>
 
-<?php if ($this->showDatabase): ?>
+<?php if (isset($this->admin['database'])): ?>
     <!-- DB -->
     <div id="adminPanel_extension_sub5">
         <div class="adminPanel_extension_panel_header">


### PR DESCRIPTION
The idea was to _not_ display the database tab in admin panel, if the user has no permissions.

One problem was, that a fresh install did not allow the admin user to see it, because the visibility of the tab is restricted to the "show sensitive data" log setting (which needs to be fixed). 

@ServiusHack : Could you take care of that? I do not know the permission system yet. Look out for a FIXME in ki_adminpane/init.php
