### PR TITLE
Correctly escape values when updating autoconf.php. (closes #215)

### DIFF
--- a/core/includes/func.php
+++ b/core/includes/func.php
@@ -282,6 +282,12 @@ function createPassword($length) {
 }
 
 function write_config_file($database,$hostname,$username,$password,$db_layer,$db_type,$prefix,$lang,$salt,$timezone = null) {
+  $database = addcslashes($database, '"$');
+  $hostname = addcslashes($hostname, '"$');
+  $username = addcslashes($username, '"$');
+  $password = addcslashes($password, '"$');
+  $timezone = addcslashes($timezone, '"$');
+
   $file=fopen(realpath(dirname(__FILE__)).'/autoconf.php','w');
   if (!$file) return false;
   if (empty($timezone)) { $timezone = 'date_default_timezone_get()'; } else { $timezone = '"' . $timezone . '"'; }

--- a/core/installer/processor.php
+++ b/core/installer/processor.php
@@ -145,11 +145,11 @@ switch ($axAction) {
     case ("write_config"):
     include("../includes/func.php");
      // special characters " and $ are escaped
-    $database    = addcslashes($_REQUEST['database'],'"$');
-    $hostname    = addcslashes($_REQUEST['hostname'],'"$');
-    $username    = addcslashes($_REQUEST['username'],'"$');
-    $password    = addcslashes($_REQUEST['password'],'"$');
-    $timezone    = addcslashes($_REQUEST['timezone'],'"$');
+    $database    = $_REQUEST['database'];
+    $hostname    = $_REQUEST['hostname'];
+    $username    = $_REQUEST['username'];
+    $password    = $_REQUEST['password'];
+    $timezone    = $_REQUEST['timezone'];
     $db_layer    = $_REQUEST['db_layer'];
     $db_type     = $_REQUEST['db_type'];
     $prefix      = addcslashes($_REQUEST['prefix'],'"$');


### PR DESCRIPTION
The responsibility to correctly escape database, hostname, username, password and timezone has been moved to write_config_file.
