### PR TITLE
Fixed permissions check when users are not in the same group.

### DIFF
--- a/core/extensions/ki_timesheets/floaters.php
+++ b/core/extensions/ki_timesheets/floaters.php
@@ -43,10 +43,15 @@ switch ($axAction) {
 
         // check if this entry may be edited
         if ($timeSheetEntry['userID'] == $kga['user']['userID']) {
+          // the user's own entry
           if (!$database->global_role_allows($kga['user']['globalRoleID'],'ki_timesheets-ownEntry-edit'))
             break;
         }
-        else if ($database->is_watchable_user($kga['user'], $timeSheetEntry['userID'])) {
+        else if (count(array_intersect(
+            $database->getGroupMemberships($kga['user']),
+            $database->getGroupMemberships($timeSheetEntry['userID'])
+          )) != 0) {
+          // same group as the entry's user
           if (!$database->checkMembershipPermission($kga['user']['userID'], $database->getGroupMemberships($timeSheetEntry['userID']),'ki_timesheets-otherEntry-ownGroup-edit'))
             break;
         }


### PR DESCRIPTION
The check if users are in the same group erroneously returned true even
if they were not. This caused the actual permission check to fail and
thus prevent editing.
