### PR TITLE
Redirect to installer when autoconf.php is missing. (closes #268)

### DIFF
--- a/core/error.php
+++ b/core/error.php
@@ -38,28 +38,22 @@ Zend_Loader_Autoloader::getInstance();
 $view = new Zend_View();
 $view->setBasePath(WEBROOT . 'templates');
 
-if (!file_exists('includes/autoconf.php')) {
-       $headline = "Fatal Error!";
-       $message = "No config-file found or it doesn't contain any data. Make sure your autoconf.php contains access-data for the database.<br/><br/>Die Konfigurations-Datei konnte nicht gefunden werden oder ist leer.";
+if (!isset($_REQUEST['err'])) {
+    $_REQUEST['err'] = '';
 }
-else {
-  if (!isset($_REQUEST['err'])) {
-      $_REQUEST['err'] = '';
-  }
 
-  switch ($_REQUEST['err']) {
+switch ($_REQUEST['err']) {
 
-    // TODO - can we make sure $kga exists?
-    case 'db':
-        $headline = $kga['lang']['errors'][0]['hdl'];
-        $message  = $kga['lang']['errors'][0]['txt'];
-    break;
-      
-    default:
-        $headline = "Unknown Error";
-        $message = "No error information was specified.";
-    break;
-  }
+  // TODO - can we make sure $kga exists?
+  case 'db':
+      $headline = $kga['lang']['errors'][0]['hdl'];
+      $message  = $kga['lang']['errors'][0]['txt'];
+  break;
+    
+  default:
+      $headline = "Unknown Error";
+      $message = "No error information was specified.";
+  break;
 }
 
 $view->assign('headline', $headline);

--- a/core/includes/basics.php
+++ b/core/includes/basics.php
@@ -44,17 +44,9 @@ $autoloader->registerNamespace('Kimai');
 
 require(WEBROOT.'includes/5.3.functions.php');
 
-if (!file_exists(WEBROOT.'includes/autoconf.php')) {
-    if (preg_match('|core/[^?]*\.php|',$_SERVER['PHP_SELF'])>0) {
-        header('location:../error.php');
-    } else {
-        header('location:error.php');
-    }
-    exit;
-}
-
-require(WEBROOT.'includes/autoconf.php');
-if (!isset($server_hostname)) {
+if (file_exists(WEBROOT.'includes/autoconf.php'))
+  require(WEBROOT.'includes/autoconf.php');
+else {
   header('location:installer/index.php');
   exit;
 }


### PR DESCRIPTION
Up until now an error message about the missing file was shown to the
user. In @4bc1c11 that file was removed from the repository thus always
giving an error to new users.

Instead of showing an error the user could immediately be redirected to
the installer. A missing autoconf.php now most likely means a plain new
installation.
