### PR TITLE
Don't divide by zero when rounding in invoice.

### DIFF
--- a/core/extensions/ki_invoice/print.php
+++ b/core/extensions/ki_invoice/print.php
@@ -160,7 +160,9 @@ if (isset($_REQUEST['round'])) {
 		// Write a logfile entry for each value that is rounded.
 		Logger::logfile("Round ".  $invoiceArray[$time_index]['hour'] . " to " . $rounded . " with ".  $round);
 
-		$rate = RoundValue($invoiceArray[$time_index]['amount']/$invoiceArray[$time_index]['hour'],0.05);
+    if ($invoiceArray[$time_index]['hour'] != 0)
+      $rate = RoundValue($invoiceArray[$time_index]['amount']/$invoiceArray[$time_index]['hour'],0.05);
+
 		$invoiceArray[$time_index]['hour'] = $rounded;
 		$invoiceArray[$time_index]['amount'] = $invoiceArray[$time_index]['hour']*$rate;
 		$time_index++;


### PR DESCRIPTION
It could happen that a duration is rounded to zero for an invoice.
In that case a DivisionByZero exception was thrown.

The offending line tries to calculate a rate so that this rate
multiiplied by th
e rounded hours gives the amount of the entry.
We just leave the rate as it is, if the rounded hour is zero.

closes #267
