### PR TITLE
Increase width of nordic time-display because it's too small

### DIFF
--- a/core/skins/nordic/timeframe.css
+++ b/core/skins/nordic/timeframe.css
@@ -10,7 +10,7 @@
     margin-left:-157px;
     top:10px;
     left:50%;
-    width: 20em;
+    width: 23em;
 }
 
 #display a,


### PR DESCRIPTION
For some dates the width set for the display in the skin nordic is too small:

![screenshot_1](https://f.cloud.github.com/assets/2362091/1571029/e501174a-50fa-11e3-9dca-0d5ee1f9ca08.png)

I'm using Chrome, didn't tested it in other browsers.

BTW: Is anyone using nordic anyway? I would include a skin like joyweb instead. 
