### PR TITLE
Fix php warnings on some systems

### DIFF
--- a/core/extensions/ki_timesheets/processor.php
+++ b/core/extensions/ki_timesheets/processor.php
@@ -431,27 +431,27 @@ switch ($axAction) {
           break;
       }
 
-      $data['projectID']      = $_REQUEST['projectID'];
-      $data['activityID']     = $_REQUEST['activityID'];
-      $data['location']       = $_REQUEST['location'];
-      $data['trackingNumber'] = $_REQUEST['trackingNumber'];
-      $data['description']    = $_REQUEST['description'];
-      $data['comment']        = $_REQUEST['comment'];
-      $data['commentType']    = $_REQUEST['commentType'];
-      if ($database->global_role_allows($kga['user']['globalRoleID'],'ki_timesheets-editRates')) {
-        $data['rate']         = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['rate']);
-        $data['fixedRate']      = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['fixedRate']);
-      } else if (!$id) {
-        $data['rate']         = $database->get_best_fitting_rate($kga['user']['userID'],$data['projectID'],$data['activityID']);
-        $data['fixedRate']      = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['fixedRate']);
-      }
-      $data['cleared']        = isset($_REQUEST['cleared']);
-      $data['statusID']       = $_REQUEST['statusID'];
-      $data['billable']       = $_REQUEST['billable'];
-      $data['budget']         = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['budget']);
-      $data['approved']       = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['approved']);
-      $data['userID']         = $_REQUEST['userID'];
+      if (isset($_REQUEST['projectID']))      { $data['projectID']      = $_REQUEST['projectID']; }
+      if (isset($_REQUEST['activityID']))     { $data['activityID']     = $_REQUEST['activityID']; }
+      if (isset($_REQUEST['location']))       { $data['location']       = $_REQUEST['location']; }
+      if (isset($_REQUEST['trackingNumber'])) { $data['trackingNumber'] = $_REQUEST['trackingNumber']; }
+      if (isset($_REQUEST['description']))    { $data['description']    = $_REQUEST['description']; }
+      if (isset($_REQUEST['comment']))        { $data['comment']        = $_REQUEST['comment']; }
+      if (isset($_REQUEST['commentType']))    { $data['commentType']    = $_REQUEST['commentType']; }
+      if (isset($_REQUEST['statusID']))       { $data['statusID']       = $_REQUEST['statusID']; }
+      if (isset($_REQUEST['billable']))       { $data['billable']       = $_REQUEST['billable']; }
+      if (isset($_REQUEST['budget']))         { $data['budget']         = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['budget']); }
+      if (isset($_REQUEST['approved']))       { $data['approved']       = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['approved']); }
+      if (isset($_REQUEST['userID']))         { $data['userID']         = $_REQUEST['userID']; }
+      $data['cleared']                                                  = isset($_REQUEST['cleared']);
 
+      if ($database->global_role_allows($kga['user']['globalRoleID'],'ki_timesheets-editRates')) {
+          if (isset($_REQUEST['rate']))       { $data['rate']           = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['rate']); }
+          if (isset($_REQUEST['fixedRate']))  { $data['fixedRate']      = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['fixedRate']); }
+      } else if (!$id) {
+          if (isset($_REQUEST['rate']))       { $data['rate']           = $database->get_best_fitting_rate($kga['user']['userID'],$data['projectID'],$data['activityID']); }
+          if (isset($_REQUEST['fixedRate']))  { $data['fixedRate']      = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['fixedRate']); }
+      }
 
       // check if the posted time values are possible
 

--- a/core/libraries/Kimai/Database/Mysql.php
+++ b/core/libraries/Kimai/Database/Mysql.php
@@ -1799,46 +1799,47 @@ class Kimai_Database_Mysql extends Kimai_Database_Abstract {
       return $this->conn->Query($query);
   }
 
- /**
-  * create time sheet entry
-  *
-  * @param integer $id    ID of record
-  * @param integer $data  array with record data
-  * @author th
-  */
-  public function timeEntry_create($data) {
-      $data = $this->clean_data($data);
+	/**
+	 * create time sheet entry
+	 *
+	 * @param integer $id    ID of record
+	 * @param integer $data  array with record data
+	 * @author th
+	 */
+	public function timeEntry_create($data) {
+		$data = $this->clean_data($data);
 
-      $values ['location']     =   MySQL::SQLValue( $data ['location'] );
-      $values ['comment']      =   MySQL::SQLValue( $data ['comment'] );
-      $values ['description']      =   MySQL::SQLValue( $data ['description'] );
-      if ($data ['trackingNumber'] == '')
-        $values ['trackingNumber'] = 'NULL';
-      else
-        $values ['trackingNumber'] =   MySQL::SQLValue( $data ['trackingNumber'] );
-      $values ['userID']        =   MySQL::SQLValue( $data ['userID']       , MySQL::SQLVALUE_NUMBER );
-      $values ['projectID']        =   MySQL::SQLValue( $data ['projectID']       , MySQL::SQLVALUE_NUMBER );
-      $values ['activityID']        =   MySQL::SQLValue( $data ['activityID']       , MySQL::SQLVALUE_NUMBER );
-      $values ['commentType'] =   MySQL::SQLValue( $data ['commentType'] , MySQL::SQLVALUE_NUMBER );
-      $values ['start']           =   MySQL::SQLValue( $data ['start']           , MySQL::SQLVALUE_NUMBER );
-      $values ['end']          =   MySQL::SQLValue( $data ['end']          , MySQL::SQLVALUE_NUMBER );
-      $values ['duration']         =   MySQL::SQLValue( $data ['duration']         , MySQL::SQLVALUE_NUMBER );
-      $values ['rate']         =   MySQL::SQLValue( $data ['rate']         , MySQL::SQLVALUE_NUMBER );
-      $values ['cleared']      =   MySQL::SQLValue( $data ['cleared']?1:0  , MySQL::SQLVALUE_NUMBER );
-      $values ['budget']   	   =   MySQL::SQLValue($data ['budget']   	   , MySQL::SQLVALUE_NUMBER );
-      $values ['approved'] 	   =   MySQL::SQLValue($data ['approved']      , MySQL::SQLVALUE_NUMBER );
-      $values ['statusID']   	   =   MySQL::SQLValue($data ['statusID']   	   , MySQL::SQLVALUE_NUMBER );
-      $values ['billable'] 	   =   MySQL::SQLValue($data ['billable'] 	   , MySQL::SQLVALUE_NUMBER );
+		if (isset($data['comment'])) { $values ['comment']           = MySQL::SQLValue( $data ['comment'] ); }
+		if (isset($data['isDesignWork'])) { $values ['isDesignWork'] = MySQL::SQLValue( $data ['isDesignWork'] ); }
+		if (isset($data['description'])) { $values ['description']   = MySQL::SQLValue( $data ['description'] ); }
+		if (isset($data['trackingNumber'])) {
+			if ($data ['trackingNumber'] == '') { $values ['trackingNumber'] = 'NULL'; } else {
+				$values ['trackingNumber'] = MySQL::SQLValue( $data ['trackingNumber'] );
+			}
+		}
+		if (isset($data['userID'])) { $values ['userID']           = MySQL::SQLValue( $data ['userID']      , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['projectID'])) { $values ['projectID']     = MySQL::SQLValue( $data ['projectID']   , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['activityID'])) { $values ['activityID']   = MySQL::SQLValue( $data ['activityID']  , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['commentType'])) { $values ['commentType'] = MySQL::SQLValue( $data ['commentType'] , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['start'])) { $values ['start']             = MySQL::SQLValue( $data ['start']       , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['end'])) { $values ['end']                 = MySQL::SQLValue( $data ['end']         , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['duration'])) { $values ['duration']       = MySQL::SQLValue( $data ['duration']    , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['rate'])) { $values ['rate']               = MySQL::SQLValue( $data ['rate']        , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['cleared'])) { $values ['cleared']         = MySQL::SQLValue( $data ['cleared']?1:0 , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['budget'])) { $values ['budget']           = MySQL::SQLValue($data ['budget']       , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['approved'])) { $values ['approved']       = MySQL::SQLValue($data ['approved']     , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['statusID'])) { $values ['statusID']       = MySQL::SQLValue($data ['statusID']     , MySQL::SQLVALUE_NUMBER ); }
+		if (isset($data['billable'])) { $values ['billable']       = MySQL::SQLValue($data ['billable']     , MySQL::SQLVALUE_NUMBER ); }
 
-      $table = $this->getTimeSheetTable();
-      $success =  $this->conn->InsertRow($table, $values);
-      if ($success)
-        return  $this->conn->GetLastInsertID();
-      else {
-        $this->logLastError('timeEntry_create');
-        return false;
-      }
-  }
+		$table = $this->getTimeSheetTable();
+		$success =  $this->conn->InsertRow($table, $values);
+		if ($success)
+			return  $this->conn->GetLastInsertID();
+		else {
+			$this->logLastError('timeEntry_create');
+			return false;
+		}
+	}
 
 
   /**

--- a/core/libraries/Kimai/Database/Mysql.php
+++ b/core/libraries/Kimai/Database/Mysql.php
@@ -1810,7 +1810,7 @@ class Kimai_Database_Mysql extends Kimai_Database_Abstract {
 		$data = $this->clean_data($data);
 
 		if (isset($data['comment'])) { $values ['comment']           = MySQL::SQLValue( $data ['comment'] ); }
-		if (isset($data['isDesignWork'])) { $values ['isDesignWork'] = MySQL::SQLValue( $data ['isDesignWork'] ); }
+		if (isset($data['location'])) { $values ['location']         = MySQL::SQLValue( $data ['location'] ); }
 		if (isset($data['description'])) { $values ['description']   = MySQL::SQLValue( $data ['description'] ); }
 		if (isset($data['trackingNumber'])) {
 			if ($data ['trackingNumber'] == '') { $values ['trackingNumber'] = 'NULL'; } else {

--- a/core/libraries/mysql.class.php
+++ b/core/libraries/mysql.class.php
@@ -1574,8 +1574,9 @@ class MySQL
 				//	$return_value = "NULL";
 				//} else {
 
-						//TODO: Find out why we need is_array here. Why is an array submitted in the first place? Occurred when using the timer.
+						//TODO: Find out why we need is_array here. Why is an array submitted in the first place?
 					if (is_array($value)) {
+							Logger::logfile("MySQL::SQLValue value appeared to be an array:\n" . print_r($value, true) . "\nSetting it empty to avoid warnings.");
 							// Set empty so mysql_real_escape_string doesn't produce a warning
 							// Otherwise it would produce the warning and $return_value would be "''"
 						$value = '';

--- a/core/libraries/mysql.class.php
+++ b/core/libraries/mysql.class.php
@@ -1573,6 +1573,14 @@ class MySQL
 				//if (strlen($value) == 0) {
 				//	$return_value = "NULL";
 				//} else {
+
+						//TODO: Find out why we need is_array here. Why is an array submitted in the first place? Occurred when using the timer.
+					if (is_array($value)) {
+							// Set empty so mysql_real_escape_string doesn't produce a warning
+							// Otherwise it would produce the warning and $return_value would be "''"
+						$value = '';
+					}
+
 					if (get_magic_quotes_gpc()) {
 						$value = stripslashes($value);
 					}


### PR DESCRIPTION
Commit a0ae103:
When starting the timer, sometimes an array is used in mysql_real_escape_string, 
which results in empty string and a warning:
"Warning: mysql_real_escape_string() expects parameter 1 to be string, array given in /var/www/zeiten_multiple/live/core/libraries/mysql.class.php on line 1579‏"
Nothing dangerous. Also I wasn't able to reproduce the warning, therefore I don't know why it gets an array there - so I applied a hotfix, resulting in the same result without the warning. Added a TODO comment.

Commit 2737f23:
This is slightly more important, since warnings in the ajax response kills the handling of them.
When using certain settings some values aren't used, therefore they generate a warning because the variable doesn't exist. I added various isset()-querys.
