### PR TITLE
Hide user list when unusable for filtering.

### DIFF
--- a/core/templates/scripts/core/main.php
+++ b/core/templates/scripts/core/main.php
@@ -139,7 +139,7 @@
     $('#usersShrink').hide();
   <?php endif; ?>
 
-  <?php if ($this->kga['conf']['user_list_hidden']): ?>
+  <?php if ($this->kga['conf']['user_list_hidden'] or count($this->users) <= 1): ?>
     lists_shrinkUserToggle();
   <?php endif; ?>
     $('#projects>table>tbody>tr>td>a.preselect#ps'+selected_project+'>img').attr('src','../skins/'+skin+'/grfx/preselect_on.png');


### PR DESCRIPTION
The user list is hidden when it is empty or contains just one user. In
both cases it is of no use to the currently logged in user.
