### PR TITLE
added new description field to timesheet extension of the standard theme

### DIFF
--- a/core/extensions/ki_timesheets/css/tables.css.php
+++ b/core/extensions/ki_timesheets/css/tables.css.php
@@ -115,6 +115,12 @@ div.ki_timesheet>div#timeSheet>div#timeSheetTable>table>tbody>tr>td.username {
     width:40px;
 }
 
+#timeSheet_head td.description,
+#timeSheet td.description
+{
+    width:450px;
+}
+
 #timeSheet_head td.from,
 #timeSheet_head td.to,
 #timeSheet td.from,

--- a/core/extensions/ki_timesheets/templates/scripts/main.php
+++ b/core/extensions/ki_timesheets/templates/scripts/main.php
@@ -24,6 +24,7 @@
           <col class="project" />
           <col class="activity" />
         <?php if ($this->showTrackingNumber) { ?>
+          <col class="description" />
           <col class="trackingnumber" />
         <?php } ?>
           <col class="username" />
@@ -42,6 +43,7 @@
                 <td class="project"><?php echo $this->kga['lang']['project']?></td>
                 <td class="activity"><?php echo $this->kga['lang']['activity']?></td>
             <?php if ($this->showTrackingNumber) { ?>
+                <td class="description"><?php echo $this->kga['lang']['description']?></td>
                 <td class="trackingnumber"><?php echo $this->kga['lang']['trackingNumber']?></td>
             <?php } ?>
                 <td class="username"><?php echo $this->kga['lang']['username']?></td>

--- a/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -22,6 +22,7 @@ if ($this->timeSheetEntries)
               <col class="project" />
               <col class="activity" />
             <?php if ($this->showTrackingNumber) { ?>
+              <col class="description" />
               <col class="trackingnumber" />
             <?php } ?>
               <col class="username" />
@@ -188,6 +189,12 @@ if ($this->timeSheetEntries)
             </td>
 
             <?php if ($this->showTrackingNumber) { ?>
+            <td class="description <?php echo $tdClass; ?>" >
+              <?php echo $this->escape($this->truncate($row['description'],50,'...')) ?>
+                <?php if ($row['description']): ?>
+                <a href="#" onClick="$(this).blur();  return false;" ><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase_sys.gif' width="12" height="13" title='<?php echo $this->escape($row['description'])?>' border="0" /></a>
+              <?php endif; ?>
+            </td>
             <td class="trackingnumber <?php echo $tdClass; ?>">
                 <?php echo $this->escape($row['trackingNumber']) ?>
             </td>

--- a/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -201,7 +201,11 @@ if ($this->timeSheetEntries)
             <?php } ?>
 
             <td class="username <?php echo $tdClass; ?>">
+              <?php if ($row['userAlias']): ?>
+                <?php echo $this->escape($row['userAlias']) . ' (' . $this->escape($row['userName']) . ')' ?>
+              <?php else: ?>
                 <?php echo $this->escape($row['userName']) ?>
+              <?php endif; ?>
             </td>
 
         </tr>

--- a/core/language/de.php
+++ b/core/language/de.php
@@ -279,7 +279,7 @@ return array(
 'editLimitError'            => 'Das Enddatum liegt weiter in der Vergangenheit, als es erlaubt wurde.',
 'hideClearedEntries'        => 'abgerechnete Einträge verstecken',
 'showCommentsByDefault'     => 'Kommentare standardmäßig anzeigen',
-'showTrackingNumber'        => 'Auftragsnummer anzeigen',
+'showTrackingNumber'        => 'Auftragsnummer und Beschreibung in Zeiterfassung anzeigen',
 'hideOverlapLines'          => 'Zeitüberschneidungen nicht markieren',
 'general'                   => 'Allgemein',
 'address'                   => 'Adresse',

--- a/core/language/en.php
+++ b/core/language/en.php
@@ -299,7 +299,7 @@ return array(
 
 'hideClearedEntries'        => 'hide cleared entries',
 'showCommentsByDefault'     => 'show comments by default',
-'showTrackingNumber'        => 'show tracking number',
+'showTrackingNumber'        => 'show tracking number and description details in timesheet',
 'hideOverlapLines'          => 'Don\'t indicate time overlap of entries',
 
 'general' => 'General',

--- a/core/skins/standard/selector.css
+++ b/core/skins/standard/selector.css
@@ -2,7 +2,7 @@
     background: url("grfx/g3_buzzer_display.png") no-repeat;
     color:#51534A;
     overflow:hidden;
-    width:224px;
+    width:254px;
     height:69px;
     display:block;
     position:absolute;
@@ -14,16 +14,16 @@
 }
 
 #selector .preselection {
-    width:205px;
-    height:52px;
-    padding:7px 10px 0 ;
+    width:225px;
+    height:62px;
+    padding:5px 10px 0 ;
     overflow:hidden;
     line-height:13px;
 }
 
 #selector span.selection {
     overflow:hidden;
-    width:190px;
+    width:210px;
     height:13px;
     display:block;
     float:left;


### PR DESCRIPTION
hi, I pushed some new features regarding the new description field and the standard theme.

 1   show the new description field as shortened column within timesheet, and toggle it by showtrackingnumber-flag (this is easier to use if there is only one checkbox for details in timesheetextension, at the moment i fitted languages en and de only)
 2  show user alias if present instead of username only in timesheet extension - what else should be alias for?!
 3   Resize Task Picker Status Area (upper right corner) to fit longer verbings in FF and IE. it is annoying if one can see only customer and project but not the task in the field, since german language headings need two lines of text. easier might it be, to resize the field in total. TODO: the background image (g3_buzzer_display) should be resized, too, by 2px more in height and 20-30px more width, I don't have the psd ...

this are the same changes as in pull request #297 that was closed but not merged because of a "Merge remote branch 'upstream/master' into mybranch", i.e. my false previous commit mfriedr2@8954d1d (8954d1da350124321ce22adf22c08018b87b8d21)
