### PR TITLE
Refactored creation of sublist annotations. (closes #132)

### DIFF
--- a/core/extensions/ki_expenses/templates/scripts/expenses.php
+++ b/core/extensions/ki_expenses/templates/scripts/expenses.php
@@ -154,35 +154,11 @@ else
 ?>
 
 <script type="text/javascript"> 
-    expense_user_annotations = null;
-    expense_customer_annotations = null;
-    expense_project_annotations = null;
-    expense_activity_annotations = null;
+    expense_user_annotations = <?php echo json_encode($this->user_annotations); ?>;
+    expense_customer_annotations = <?php echo json_encode($this->customer_annotations) ?>;
+    expense_project_annotations = <?php echo json_encode($this->project_annotations) ?>;
+    expense_activity_annotations = <?php echo json_encode($this->activity_annotations) ?>;
     expenses_total = '<?php echo $this->total?>';
-
-    <?php if ($this->user_annotations): ?>
-    expense_user_annotations = new Array();
-    <?php foreach ($this->user_annotations as $id => $value): ?>
-      expense_user_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->customer_annotations): ?>
-    expense_customer_annotations = new Array();
-    <?php foreach ($this->customer_annotations as $id => $value): ?>
-      expense_customer_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->project_annotations): ?>
-    expense_project_annotations = new Array();
-    <?php foreach ($this->project_annotations as $id => $value): ?>
-      expense_project_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->activity_annotations): ?>
-    expense_activity_annotations = new Array();
-    <?php foreach ($this->activity_annotations as $id => $value): ?>
-      expense_activity_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
     
     lists_update_annotations(parseInt($('#gui div.ki_expenses').attr('id').substring(7)),expense_user_annotations,expense_customer_annotations,expense_project_annotations,expense_activity_annotations);
     $('#display_total').html(expenses_total);

--- a/core/extensions/ki_export/templates/scripts/table.php
+++ b/core/extensions/ki_export/templates/scripts/table.php
@@ -257,35 +257,11 @@ endforeach;
 <?php endif; ?>
 
 <script type="text/javascript"> 
-    ts_user_annotations = null;
-    ts_customer_annotations = null;
-    ts_project_annotations = null;
-    ts_activity_annotations = null;
+    ts_user_annotations = <?php echo json_encode($this->user_annotations); ?>;
+    ts_customer_annotations = <?php echo json_encode($this->customer_annotations) ?>;
+    ts_project_annotations = <?php echo json_encode($this->project_annotations) ?>;
+    ts_activity_annotations = <?php echo json_encode($this->activity_annotations) ?>;
     ts_total = '<?php echo $this->total?>';
-
-    <?php if ($this->user_annotations): ?>
-    ts_user_annotations = new Array();
-    <?php foreach ($this->user_annotations as $id => $value): ?>
-      ts_user_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->customer_annotations): ?>
-    ts_customer_annotations = new Array();
-    <?php foreach ($this->customer_annotations as $id => $value): ?>
-      ts_customer_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->project_annotations): ?>
-    ts_project_annotations = new Array();
-    <?php foreach ($this->project_annotations as $id => $value): ?>
-      ts_project_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->activity_annotations): ?>
-    ts_activity_annotations = new Array();
-    <?php foreach ($this->activity_annotations as $id => $value): ?>
-      ts_activity_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
     
     lists_update_annotations(parseInt($('#gui div.ki_export').attr('id').substring(7)),ts_user_annotations,ts_customer_annotations,ts_project_annotations,ts_activity_annotations);
     $('#display_total').html(ts_total);

--- a/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -224,35 +224,11 @@ else
 ?>
 
 <script type="text/javascript"> 
-    ts_user_annotations = null;
-    ts_customer_annotations = null;
-    ts_project_annotations = null;
-    ts_activity_annotations = null;
+    ts_user_annotations = <?php echo json_encode($this->user_annotations); ?>;
+    ts_customer_annotations = <?php echo json_encode($this->customer_annotations) ?>;
+    ts_project_annotations = <?php echo json_encode($this->project_annotations) ?>;
+    ts_activity_annotations = <?php echo json_encode($this->activity_annotations) ?>;
     ts_total = '<?php echo $this->total?>';
-
-    <?php if ($this->user_annotations): ?>
-    ts_user_annotations = new Array();
-    <?php foreach ($this->user_annotations as $id => $value): ?>
-      ts_user_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->customer_annotations): ?>
-    ts_customer_annotations = new Array();
-    <?php foreach ($this->customer_annotations as $id => $value): ?>
-      ts_customer_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->project_annotations): ?>
-    ts_project_annotations = new Array();
-    <?php foreach ($this->project_annotations as $id => $value): ?>
-      ts_project_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
-
-    <?php if ($this->activity_annotations): ?>
-    ts_activity_annotations = new Array();
-    <?php foreach ($this->activity_annotations as $id => $value): ?>
-      ts_activity_annotations[<?php echo $id?>] = '<?php echo $value?>';
-    <?php endforeach; endif; ?>
     
     lists_update_annotations(parseInt($('#gui div.ki_timesheet').attr('id').substring(7)),ts_user_annotations,ts_customer_annotations,ts_project_annotations,ts_activity_annotations);
     $('#display_total').html(ts_total);

--- a/core/js/init.js
+++ b/core/js/init.js
@@ -42,10 +42,10 @@ var filterActivities = new Array();
 
 var lists_visibility = new Array();
 
-var lists_user_annotations = new Array();
-var lists_customer_annotations = new Array();
-var lists_project_annotations = new Array();
-var lists_activity_annotations = new Array();
+var lists_user_annotations = {};
+var lists_customer_annotations = {};
+var lists_project_annotations = {};
+var lists_activity_annotations = {};
 
 $(document).ready(function() {
   


### PR DESCRIPTION
Using json_encode we solve the escape issue and have less lines. Only
difference is that the annotation variables are now object and not
arrays. But that makes no difference.
