### PR TITLE
Handle wrong database credentials ...

### DIFF
--- a/core/includes/basics.php
+++ b/core/includes/basics.php
@@ -103,6 +103,7 @@ if (isset($_REQUEST['database'])) {
 
 $database = new Kimai_Database_Mysql($kga);
 $database->connect($kga['server_hostname'],$kga['server_database'],$kga['server_username'],$kga['server_password'],$kga['utf8'],$kga['server_type'] );
+if (!$database->isConnected()) { die('Kimai could not connect to database. Check your autoconf.php.'); }
 Kimai_Registry::setDatabase($database);
 
 global $translations;

--- a/core/libraries/Kimai/Database/Mysql.php
+++ b/core/libraries/Kimai/Database/Mysql.php
@@ -38,6 +38,10 @@ class Kimai_Database_Mysql extends Kimai_Database_Abstract {
       $this->conn = new MySQL(true, $database, $host, $username, $password);
   }
 
+  public function isConnected() {
+      return $this->conn->IsConnected();
+  }
+
   private function logLastError($scope) {
       Logger::logfile($scope.': '.$this->conn->Error());
   }


### PR DESCRIPTION
... or empty autoconf.php

Which resulted in hundreds of log entries and finally a white page. 
The underlying error was hard to spot (especially for non techies)

Happened for example with an empty autoconf.php which was existing in the beta version - see #349
