### PR TITLE
Implement new password hashing scheme.

### DIFF
--- a/core/core/processor.php
+++ b/core/core/processor.php
@@ -92,7 +92,7 @@ switch ($axAction) {
         
         // If the password field is empty don't overwrite the old password.
         if (trim($_REQUEST['password']) != "") {
-            $userData['password'] = md5($kga['password_salt'].$_REQUEST['password'].$kga['password_salt']);
+            $userData['password'] = encode_password($_REQUEST['password']);
             $database->user_edit($kga['user']['userID'], $userData);
         }
         
@@ -230,7 +230,7 @@ switch ($axAction) {
         
               // If password field is empty dont overwrite the password.
               if (isset($_REQUEST['password']) && $_REQUEST['password'] != "") {
-                $data['password'] = md5($kga['password_salt'].$_REQUEST['password'].$kga['password_salt']);
+                $data['password'] = encode_password($_REQUEST['password']);
               }
               if (isset($_REQUEST['no_password']) && $_REQUEST['no_password']) {
                 $data['password'] = '';

--- a/core/extensions/ki_adminpanel/processor.php
+++ b/core/extensions/ki_adminpanel/processor.php
@@ -384,7 +384,7 @@ switch ($axAction)
                 $userData['rate'] = str_replace($kga['conf']['decimalSeparator'],'.',$_REQUEST['rate']);
 		// if password field is empty => password unchanged (not overwritten with "")
 		if ($_REQUEST['password'] != "") {
-			$userData['password'] = md5($kga['password_salt'] . $_REQUEST['password'] . $kga['password_salt']);
+			$userData['password'] = encode_password($_REQUEST['password']);
 		}
 
                 $oldGroups = $database->getGroupMemberships($id);

--- a/core/includes/func.php
+++ b/core/includes/func.php
@@ -529,3 +529,17 @@ function coreObjectActionAllowed($objectTypeName, $action) {
 
   return false;
 }
+
+/**
+ * Encode a provided password as we need it to store in the DB.
+ *
+ * @param $password the password string to encode
+ * @return the encoded password string
+ */
+function encode_password($password) {
+  // use crypt with SHA-256 and 5000 rounds. As the actual salt we take the
+  // first 16 chars from a MD5 string.
+  $salt = '$5$rounds=5000$' . substr(md5(microtime()), 0, 16);
+  $pepper = $kga['password_salt'];
+  return crypt($pepper . $password, $salt);
+}

--- a/core/index.php
+++ b/core/index.php
@@ -147,7 +147,7 @@ switch($_REQUEST['a'])
 
         if ($is_customer) {
           // perform login of customer
-          $passCrypt = md5($kga['password_salt'].$password.$kga['password_salt']);
+          $passCrypt = encode_password($password);
           $id = $database->customer_nameToID($name);
           $data = $database->customer_get_data($id);
 

--- a/core/installer/install.php
+++ b/core/installer/install.php
@@ -312,7 +312,7 @@ exec_query($query);
 
 
 // ADMIN USER
-$adminPassword =  md5($kga['password_salt'].'changeme'.$kga['password_salt']);
+$adminPassword =  encode_password('changeme');
 $query="INSERT INTO `${p}users` (`userID`,`name`,`mail`,`password`, `globalRoleID` ) VALUES ('$randomAdminID','admin','admin@yourwebspace.de','$adminPassword',1);";
 exec_query($query);
 

--- a/core/libraries/Kimai/Auth/Http.php
+++ b/core/libraries/Kimai/Auth/Http.php
@@ -109,7 +109,7 @@ class Kimai_Auth_Http extends Kimai_Auth_Abstract {
         $this->database->setGroupMemberships($userId,array($this->getDefaultGroups()));
 
     	// Set a random password, unknown to the user. Autologin must be used until user sets own password
-	$userData = array('password' => md5($kga['password_salt'] . md5(uniqid(rand(), true)) . $kga['password_salt']));
+	$userData = array('password' => $this->encode_password(md5(uniqid(rand(), true))));
 	$this->database->user_edit($userId, $userData);
 	return true;
 	}
@@ -117,26 +117,4 @@ class Kimai_Auth_Http extends Kimai_Auth_Abstract {
     return false;
   }
 
-  public function authenticate($username,$password,&$userId) {
-      global $kga;
-
-      $passCrypt = md5($kga['password_salt'].$password.$kga['password_salt']);
-
-      $result = mysql_query(sprintf("SELECT * FROM %susers WHERE name ='%s';",$kga['server_prefix'],mysql_real_escape_string($username)));
-      if (mysql_num_rows($result) != 1) {
-        $userId = false;
-        return false;
-      }
-
-      $row    = mysql_fetch_assoc($result);
-      $pass    = $row['password'];        
-      $ban     = $row['ban'];
-      $banTime = $row['banTime'];   
-      $userId  = $row['userID'];
-      
-      return $pass==$passCrypt && $username!="";
-  }
 }
-
-// There should be NO trailing whitespaces.
-?>

--- a/core/libraries/Kimai/Auth/Kimai.php
+++ b/core/libraries/Kimai/Auth/Kimai.php
@@ -19,31 +19,6 @@
 
 class Kimai_Auth_Kimai extends Kimai_Auth_Abstract
 {
-    /**
-     * @param $username
-     * @param $password
-     * @param $userId
-     * @return bool
-     */
-    public function authenticate($username, $password, &$userId)
-    {
-        $kga      = $this->getKga();
-        $database = $this->getDatabase();
-
-        $id = $database->user_name2id($username);
-
-        if ($id === false) {
-            $userId = false;
-            return false;
-        }
-
-        $passCrypt = md5($kga['password_salt'].$password.$kga['password_salt']);
-        $userData  = $database->user_get_data($id);
-        $pass      = $userData['password'];
-        $userId    = $userData['userID'];
-
-        return $pass==$passCrypt && $username!="";
-    }
 
     public function forgotPassword($name)
     {
@@ -84,7 +59,7 @@ class Kimai_Auth_Kimai extends Kimai_Auth_Abstract
       }
 
       $data = array();
-      $data['password'] = md5($kga['password_salt'].$password.$kga['password_salt']);
+      $data['password'] = $this->encode_password($password);
       $data['passwordResetHash'] = null;
       $database->user_edit($id, $data);
 

--- a/core/libraries/Kimai/Auth/Ldap.php
+++ b/core/libraries/Kimai/Auth/Ldap.php
@@ -86,7 +86,8 @@ class Kimai_Auth_Ldap extends Kimai_Auth_Abstract {
                 $this->database->setGroupMemberships($userId,array($this->getDefaultGroups()));
 
                 // Set a password, to calm kimai down
-                $usr_data = array('password' => md5($this->kga['password_salt'] . md5(uniqid(rand(), true)) . $this->kga['password_salt']));
+                // TODO #355 check wehther we need random 'password' here at all
+                $usr_data = array('password' => $this->encode_password(md5(uniqid(rand(), true))));
                 $this->database->user_edit($userId, $usr_data);
             } else {
                 $userId = false;
@@ -98,6 +99,3 @@ class Kimai_Auth_Ldap extends Kimai_Auth_Abstract {
     }
 
 }
-
-// There should be NO trailing whitespaces.
-?>

--- a/core/libraries/Kimai/Auth/Ldapadvanced.php
+++ b/core/libraries/Kimai/Auth/Ldapadvanced.php
@@ -345,7 +345,7 @@ class Kimai_Auth_Ldapadvanced extends Kimai_Auth_Abstract
                 $this->database->setGroupMemberships($userId, $this->getDefaultGroups());
 
                 // Set a password, to calm kimai down
-                $usr_data = array('password' => md5($this->kga['password_salt'] . md5(uniqid(rand(), true)) . $this->kga['password_salt']));
+                $usr_data = array('password' => $this->encode_password(md5(uniqid(rand(), true))));
                 if ($emailAddress) {
                     $usr_data['mail'] = $emailAddress;
                 }

--- a/core/processor.php
+++ b/core/processor.php
@@ -119,7 +119,7 @@ switch($_REQUEST['a'])
         }
 
         $data = array();
-        $data['password'] = md5($kga['password_salt'].$password.$kga['password_salt']);
+        $data['password'] = encode_password($password);
         $data['passwordResetHash'] = null;
         $database->customer_edit($id, $data);
         echo json_encode(array(

--- a/core/updater.php
+++ b/core/updater.php
@@ -1021,7 +1021,7 @@ if ((int)$revisionDB < 1067) {
     else
       $new_password = createPassword(8);
     exec_query("UPDATE ${p}usr SET pw = '".
-        md5($kga['password_salt'].$new_password.$kga['password_salt']).
+        encode_password($new_password).
         "' WHERE usr_ID = $user[usr_ID]");
     if ($result)    
       $new_passwords[$user['usr_name']] = $new_password;


### PR DESCRIPTION
This patch resolves #355.
# Features

The PHP built in `crypt()` function is used to encode the plaintext passwords. As the algorithm `$5$` was chosen because of compatibility reasons. This algorithm uses SHA-256 as a basis. The better `$2y$` (based on bcrypt) cannot be used since it is broken on PHP versions prior to 5.3.7 and would lead to users unable to login when the PHP version is updated.

The structure of the three new methods `encode_password()`, `verify_password()` and `password_needs_reencoding()` is similar to the new PHP Password API and the compatibility API. Once the PHP 5.3 compatibility requirement is abandoned it should be easy to switch to a newer standard API.
# TODOs / Talking points
- Currently the `crypt()` function uses 5000 rounds. That's the default and wasn't questioned.
- The `authenticate()` method is now implemented in `Abstract.php`. That's because of both `Http.php` and `Kimai.php` using it. (Btw, the`Http.php` code was/is a mess) Such methods should not exist twice. It could be placed in an intermediate class. I did not deem that necessary, though.
- The `encode_password()` function is also present in `func.php`. I'm not sure whether the Auth object is present everywhere the `encode_password()` function is needed.
