### PR TITLE
fixed docblock for method authenticate() in remote.class.php

### DIFF
--- a/core/includes/classes/remote.class.php
+++ b/core/includes/classes/remote.class.php
@@ -149,7 +149,7 @@ class Kimai_Remote_Api
      *
      * @param string $username
      * @param string $password
-     * @return string
+     * @return array
      */
     public function authenticate($username, $password)
     {


### PR DESCRIPTION
When trying to use the SOAP API I wondered why the returned "apiKey" is always "Array"...
The return value in the Docblock was set to "string" but it should be "array"; so the zend_soap_server converts the result, created by $this->getSuccessResponse(), the right way.
