### PR TITLE
Adds a highly configurable LDAP-Adapter

### DIFF
--- a/core/libraries/Kimai/Auth/LDAP_README.md
+++ b/core/libraries/Kimai/Auth/LDAP_README.md
@@ -1,17 +1,17 @@
-# LDAP-Authentication
+# Advanced LDAP-Authentication
 
 ## Usage
 
-To use LDAP-Authentication in kimai you will have to do one of the following:
+To use the advanced LDAP-Authentication in kimai you will have to do one of the following:
 
- * create a new class "Kimai_Auth_Yourname" (where "yourname has to be lowercase ecept for the first character) that extends Kiami_Auth_Ldap and overwrite the properties of Kimai_Auth_Ldap with your data or
- * Simply configure the stuff in the Kimai_Auth_Ldap class by overwriting the defaults for the properties
+ * create a new class "Kimai_Auth_Yourname" (where "yourname has to be lowercase ecept for the first character) that extends Kiami_Auth_Ldapadvanced and overwrite the properties of Kimai_Auth_Ldapadvanced with your data or
+ * Simply configure the stuff in the Kimai_Auth_Ldapadvanced class by overwriting the defaults for the properties
 
 Then you will have to add the following line to your ```includes/autofonf.php```-file:
 
     $authenticator = 'yourname';
 
-*yourname* is the last part of the classname, this time completely in lowercase. If you overwrote the properties from Kimai_Auth_Ldap it is simply ```ldap```
+*yourname* is the last part of the classname, this time completely in lowercase. If you overwrote the properties from Kimai_Auth_Ldapadvanced it is simply ```ldapadvanced```
 
 ## Configuration-parameters
 

--- a/core/libraries/Kimai/Auth/LDAP_README.md
+++ b/core/libraries/Kimai/Auth/LDAP_README.md
@@ -1,0 +1,36 @@
+# LDAP-Authentication
+
+## Usage
+
+To use LDAP-Authentication in kimai you will have to do one of the following:
+
+ * create a new class "Kimai_Auth_Yourname" (where "yourname has to be lowercase ecept for the first character) that extends Kiami_Auth_Ldap and overwrite the properties of Kimai_Auth_Ldap with your data or
+ * Simply configure the stuff in the Kimai_Auth_Ldap class by overwriting the defaults for the properties
+
+Then you will have to add the following line to your ```includes/autofonf.php```-file:
+
+    $authenticator = 'yourname';
+
+*yourname* is the last part of the classname, this time completely in lowercase. If you overwrote the properties from Kimai_Auth_Ldap it is simply ```ldap```
+
+## Configuration-parameters
+
+ * **host:** This is the URI to connect with your LDAP-Server. This can be something like ```ldap://ldap.example.com``` or ``` ldaps://ldap.example.com:1234```
+ * **bindDN:** This is the DN of a user with read access to the LDAP. Leave empty when your LDAP supports anonymous bind
+ * **bindPW:** the password for the user with read access to the LDAP. Leave empty also for anonymous bind
+ * **searchBase:** Where do your searches start in the ldap. This is normaly something like ```o=example,c=org```
+ * **userFilter:** What filter shall be used to search for a user. The string ```%1$s``` will be replaced with what the user entered as login name. You can use that string multiple times to enable login by UID **and** email. The filter would then be ```(|(uid=%1$s)(mail=%1$s))```
+ * **groupFilter:** What filter shall be used to heck for group memberships. The string ```%1$s``` will be replaced by the value of the attribute defined by ```usernameAttribute``` of the user-entry. The string ```%2$s``` will be replaced by the DN of the users entry;
+ * **usernameAttribute:** The attribute to be sed to check for group memberships **as well as** retrieving the username to be used by kimai
+ * **commonNameAttribute:** This attribute defines the alias of the user in kimai
+ * **groupidAttribute:** This attribute contains the value that is represented in the ```allowedGroupIds```
+ * **mailAttribute:** This attribute holds the users email-address that will be ported to kimai
+ * **allowedGroupIds:** An array of values defined by ```groupidAttribute```. Members of the LDAP-groups referenced here will be allowed access to kimai!
+ * **forceLowercase:** Whether the username for kimai shall be lowercased or not.
+ * **nonLdapAcounts:** A list of kimai-usernames that shall **not** be autehnticated via LDAP but via the default kimai-authentication-adapter
+ * **autocreateUsers:** Shall uses authenticated via LDAP be created automatically in kimai. If set to false the users have to be added manually to kimai and only password-verification will be handled via LDAP
+ * **defaultGlobalRoleName:** The name of the default role newly created users will be associated with
+ * **defaultGroupMemberships:** An array of group=>role mappings the user shall also be associated with
+ 
+
+

--- a/core/libraries/Kimai/Auth/Ldap.php
+++ b/core/libraries/Kimai/Auth/Ldap.php
@@ -2,91 +2,357 @@
 
 /**
  * Copyright (C) 2011 by Skaldrom Y. Sarg of oncode.info
- *  
- * This is free software. Use it however you want.
+ * Copyright (C) 2014 by Andreas Heigl<andreas@heigl.org>
+ *
+ * This is free software. Use it however you want
+ *
+ * To activate this Authentication Adapter, add the following line to the
+ * ```includes/autoconf.php```-file:
+ *
+ *     $authenticator = 'ldap';
+ *
+ * To use your own config you can either overwrite the values given in this
+ * class or you extend this class with your own class just containing your own
+ * configuration. More Information is provided in the LDAP_README.md
+ *
+ * @author Skaldrom Y. Sarg
+ * @author Andreas Heigl<andras@heigl.org>
+ * @since  15.08.2014
  */
 
-class Kimai_Auth_Ldap extends Kimai_Auth_Abstract {
+class Kimai_Auth_Ldap extends Kimai_Auth_Abstract
+{
 
-    /** Your LDAP-Server */
-    private $LADP_SERVER = 'ldap://localhost';
-    /** Case-insensitivity of some Servers may confuse the case-sensitive-accounting system. */
-    private $LDAP_FORCE_USERNAME_LOWERCASE = true;
-    /** Preprends to username */
-    private $LDAP_USERNAME_PREFIX = 'cn=';
-    /** Appends to username */
-    private $LDAP_USERNAME_POSTFIX = ',dc=example,dc=com';
-    /** Accounts that sould be locally verified */
-    private $LDAP_LOCAL_ACCOUNTS = array('admin');
-    /** Automatically create a user in kimai if the login is successful. */
-    private $LDAP_USER_AUTOCREATE = true;
     /**
-     * @var Kimai_Auth_Kimai|null
+     * Your LDAP-Server URI
+     *
+     * Remember that you can include ldaps scheme or a port number here
+     *
+     * @var string $host
      */
-    private $kimaiAuth = null;
+    protected $host = 'ldap://localhost';
 
-    public function __construct($database = null, $kga = null) {
+    /**
+     * Bind-DN of a user that has read access to the ldap.
+     *
+     * Leave empty for anonymous bind
+     *
+     * @var string $bindDN
+     */
+    protected $bindDN = '';
+
+    /**
+     * The password to ue for non anonymous bind
+     *
+     * @var string $bindPW
+     */
+    protected $bindPW = '';
+
+    /**
+     * Search base to use
+     *
+     * @var string $searchBase
+     */
+    protected  $searchBase = 'dc=example,c=org';
+
+    /**
+     * The filter to use when searching for a user
+     *
+     * The string '%s' will be replaced by the string the user provided as username
+     *
+     * @var string $userFilter
+     */
+    protected $userFilter = 'uid=%s';
+
+    /**
+     * The filter to be used when checking group memberships
+     *
+     * The string %1$s will be replaced by the content of the attribute self::$usernameAttribute,
+     * the string %2$s will be replaced by the DN of the user
+     *
+     * @param string $groupFilter
+     */
+    protected $groupFilter = 'memberUid=%1$s';
+
+    /**
+     * Which LDAP-Attribute contains the username
+     *
+     * @param string $usernameAttribute
+     */
+    protected $usernameAttribute = 'uid';
+
+    /**
+     * Which LDAP-Attribute contains a readable username
+     *
+     * @param string $commonNameAttribute
+     */
+    protected $commonNameAttribute = 'cn';
+
+    /**
+     * Which LDAP-Attribute contains the group-id
+     *
+     * This is referenced by the entries of self::$allowedGroupIds
+     *
+     * @var string $groupidAttribute
+     */
+    protected $groupidAttribute = 'cn';
+
+    /**
+     * Which LDAP-Attribute contains the email-address
+     *
+     * This is just to set the correct mail-address for the user
+     *
+     * @var string $mailAttribute
+     */
+    protected $mailAttribute = 'mail';
+
+    /**
+     * Members of which LDAP-groups shall have access to kimai
+     *
+     * @var array $allowedGroupIds
+     */
+    protected $allowedGroupIds = array(
+        'kimai-access',
+    );
+
+    /**
+     * Shall we force usernames to lowercase?
+     *
+     * @var boolean $forceLowercase
+     */
+    protected $forceLowercase = true;
+
+    /**
+     * Accounts that sould be verified locally.
+     *
+     * All entries in this array will not be checked against the LDAP
+     *
+     * @var array $nonLdapAccounts
+     */
+    protected $nonLdapAcounts = array(
+        'admin'
+    );
+
+    /**
+     * Automatically create a user in kimai if the login is successful.
+     *
+     * @var boolean $autocreateUsers
+     */
+    protected $autocreateUsers = true;
+
+    /**
+     * The name of the default global role the user should be added to.
+     *
+     * @var string $defaultGlobalRoleName
+     */
+    protected $defaultGlobalRoleName = 'User';
+
+    /**
+     * Map of group=>role names for new users
+     *
+     * @var array $defaultGroupMemberships
+     */
+    protected $defaultGroupMemberships = array(
+        'Users' => 'User',
+    );
+
+    /**
+     * @var Kimai_Auth_Kimai $kimaiAuth
+     */
+    private $kimaiAuth;
+
+    /**
+     * {@inherit}
+     */
+    public function __construct($database = null, $kga = null)
+    {
+        if (! function_exists('ldap_bind')) {
+            throw new InvalidArgumentException('LDAP-Extension is not installed');
+        }
         parent::__construct($database, $kga);
         $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);
     }
 
-    public function authenticate($username, $password, &$userId) {
+    /**
+     * {@inherit}
+     */
+    public function authenticate($username, $password, &$userId)
+    {
         // Check if username should be authenticated locally
-        if (in_array($username, $this->LDAP_LOCAL_ACCOUNTS)) {
+        if (in_array($username, $this->nonLdapAcounts)) {
             return $this->kimaiAuth->authenticate($username, $password, $userId);
         }
 
-        // Check environment sanity
-        if (!function_exists('ldap_bind')) {
-            echo 'ldap is not installed!';
-            $userId = false;
-            return false;
-        }
 
-        // Check if username is legal
-        $check_username = trim($username);
-
-        if (!$check_username || !trim($password) || ($this->LDAP_FORCE_USERNAME_LOWERCASE && strtolower($check_username) !== $check_username)) {
+        if (! $username || ! $password) {
             $userId = false;
             return false;
         }
 
         // Connect to LDAP
-        $connect_result = ldap_connect($this->LADP_SERVER);
+        $connect_result = ldap_connect($this->host);
+
         if (!$connect_result) {
-            echo "Cannot connect to ", $this->LADP_SERVER;
+            echo "Cannot connect to ", $this->host;
             $userId = false;
             return false;
         }
 
         ldap_set_option($connect_result, LDAP_OPT_PROTOCOL_VERSION, 3);
 
-        // Try to bind. Binding means user and pwd are valid.
-        $bind_result = ldap_bind($connect_result, $this->LDAP_USERNAME_PREFIX . $check_username . $this->LDAP_USERNAME_POSTFIX, $password);
+        // Bind to the ldap and query for the given userinformation.
+        if ($this->bindDN && $this->bindPW) {
+            $bindResult = ldap_bind($connect_result, $this->bindDN, $this->bindPW);
+        } else {
+            $bindResult = ldap_bind($connect_result);
+        }
 
-        if (!$bind_result) {
-            // Nope!
+        if (! $bindResult) {
+            echo sprintf(
+                "Can't bind to the LDAP with DN %s",
+                $this->bindDN
+            );
             $userId = false;
             return false;
         }
-        ldap_unbind($connect_result);
+
+        $filter = sprintf($this->userFilter, $username);
+
+        $_ldapresults = ldap_search(
+            $connect_result,
+            $this->searchBase,
+            $filter,
+            array(
+                $this->usernameAttribute,
+                $this->mailAttribute,
+                $this->commonNameAttribute,
+            ),
+            0,
+            0,
+            10
+        );
+        if (! $_ldapresults) {
+            // The server returned no result-set at all.
+            echo "No user with that information found";
+            $userId = false;
+            return false;
+        }
+        if (1 > ldap_count_entries($connect_result, $_ldapresults)) {
+            // The returned result set contains no data.
+            echo "No user with that information found";
+            $userId = false;
+            return false;
+        }
+        if (1 < ldap_count_entries($connect_result, $_ldapresults)) {
+            // The returned result-set contains more than one person. So we
+            // can not be sure, that the user is unique.
+            echo "More than one user found with that information";
+            $userId = false;
+            return false;
+        }
+
+        $_results = ldap_get_entries($connect_result, $_ldapresults);
+        if (false === $_results) {
+            // The returned result-set could not be retrieved.
+            echo 'no result set found';
+            $userId = false;
+            return false;
+        }
+        // Empty the result set. We have the results in a variable so don't
+        // bother the server any more.
+        ldap_free_result ($_ldapresults);
+        $distinguishedName = $_results[0]['dn'];
+        $uidAttribute      = $_results[0][$this->usernameAttribute][0];
+        $emailAddress      = '';
+        $commonName        = '';
+        if (isset($_results[0][$this->mailAttribute][0])) {
+            $emailAddress = $_results[0][$this->mailAttribute][0];
+        }
+        if (isset($_results[0][$this->commonNameAttribute][0])) {
+            $commonName = $_results[0][$this->commonNameAttribute][0];
+        }
+
+        // Now lets try to bind with the returned distinguishedName and the
+        // provided passwort to the LDAP.
+        $link_id = @ldap_bind($connect_result, $distinguishedName, $password);
+        if (false === $link_id) {
+            echo 'Password and/or Username mismatch';
+            $userId = false;
+            return false;
+        }
+
+        // Check whether the user is member of one of the required LDAP-groups
+        $filter = sprintf($this->groupFilter, $uidAttribute, $distinguishedName);
+        $_ldapresults = ldap_search(
+            $connect_result,
+            $this->searchBase,
+            $filter,
+            array($this->groupidAttribute),
+            0,
+            0,
+            10
+        );
+        if (! $_ldapresults) {
+            // The server returned no result-set at all.
+            echo "No group for the user found";
+            $userId = false;
+            return false;
+        }
+        if (1 > ldap_count_entries($connect_result, $_ldapresults)) {
+            // The returned result set contains no data.
+            echo "No group for that user found";
+            $userId = false;
+            return false;
+        }
+        $_results = ldap_get_entries($connect_result, $_ldapresults);
+        if (false === $_results) {
+            // The returned result-set could not be retrieved.
+            echo 'no result set for groups found';
+            $userId = false;
+            return false;
+        }
+        ldap_free_result ( $_ldapresults );
+
+        $groups = array();
+        foreach ($_results as $result) {
+            $resultGroups = array();
+            for ($i = 0; $i < $result[$this->groupidAttribute]['count']; $i++) {
+                $resultGroups[] = $result[$this->groupidAttribute][$i];
+            }
+            $groups = array_merge($groups, $resultGroups);
+        }
+
+        if (! array_intersect($groups, $this->allowedGroupIds)) {
+            // The returned result-set could not be retrieved.
+            echo 'no valid groups found';
+            $userId = false;
+            return false;
+        }
 
         // User is authenticated. Does it exist in Kimai yet?
-        $check_username = $this->LDAP_FORCE_USERNAME_LOWERCASE ? strtolower($check_username) : $check_username;
+        $check_username = $this->forceLowercase ? strtolower($uidAttribute) : $uidAttribute;
 
         $userId = $this->database->user_name2id($check_username);
         if ($userId === false)  {
             // User does not exist (yet)
-            if ($this->LDAP_USER_AUTOCREATE) { // Create it!
-		$userId   = $this->database->user_create(array(
-			'name' => $check_username,
-			'globalRoleID' => $this->getDefaultGlobalRole(),
-			'active' => 1
-		));
-                $this->database->setGroupMemberships($userId,array($this->getDefaultGroups()));
+            if ($this->autocreateUsers) {
+                // Create it!
+                $userId = $this->database->user_create(array(
+                    'name'         => $check_username,
+                    'globalRoleID' => $this->getDefaultGlobalRole(),
+                    'active'       => 1
+                ));
+
+                $this->database->setGroupMemberships($userId, $this->getDefaultGroups());
 
                 // Set a password, to calm kimai down
                 $usr_data = array('password' => md5($this->kga['password_salt'] . md5(uniqid(rand(), true)) . $this->kga['password_salt']));
+                if ($emailAddress) {
+                    $usr_data['mail'] = $emailAddress;
+                }
+                if ($commonName) {
+                    $usr_data['alias'] = $commonName;
+                }
                 $this->database->user_edit($userId, $usr_data);
             } else {
                 $userId = false;
@@ -97,7 +363,59 @@ class Kimai_Auth_Ldap extends Kimai_Auth_Abstract {
         return true;
     }
 
-}
+    /**
+     * Get the default global role
+     *
+     * @return integer
+     */
+    public function getDefaultGlobalRole()
+    {
+        if ($this->defaultGlobalRoleName) {
+            $database = $this->getDatabase();
 
-// There should be NO trailing whitespaces.
-?>
+            $roles = $database->global_roles();
+
+            foreach ($roles as $role) {
+                if ($role['name'] == $this->defaultGlobalRoleName) {
+                    return $role['globalRoleID'];
+                }
+            }
+        }
+
+        return parent::getDefaultGlobalRole();
+    }
+
+    /**
+     * Get a map of group=>role associations for new users
+     *
+     * @return array
+     */
+    public function getDefaultGroups()
+    {
+        $groups = array();
+        $roles  = array();
+        $map    = array();
+
+        $database = $this->getDatabase();
+        foreach ($database->membership_roles() as $role) {
+            $roles[$role['name']] = $role['membershipRoleID'];
+        }
+
+        foreach ($database->get_groups() as $group) {
+            $groups[$group['name']] = $group['groupID'];
+        }
+
+        foreach ($this->defaultGroupMemberships as $group => $role) {
+            if (! isset($groups[$group])) {
+                continue;
+            }
+            if (! isset($roles[$role])) {
+                continue;
+            }
+
+            $map[$groups[$group]] = $roles[$role];
+        }
+
+        return $map;
+    }
+}

--- a/core/libraries/Kimai/Auth/Ldap.php
+++ b/core/libraries/Kimai/Auth/Ldap.php
@@ -2,357 +2,91 @@
 
 /**
  * Copyright (C) 2011 by Skaldrom Y. Sarg of oncode.info
- * Copyright (C) 2014 by Andreas Heigl<andreas@heigl.org>
- *
- * This is free software. Use it however you want
- *
- * To activate this Authentication Adapter, add the following line to the
- * ```includes/autoconf.php```-file:
- *
- *     $authenticator = 'ldap';
- *
- * To use your own config you can either overwrite the values given in this
- * class or you extend this class with your own class just containing your own
- * configuration. More Information is provided in the LDAP_README.md
- *
- * @author Skaldrom Y. Sarg
- * @author Andreas Heigl<andras@heigl.org>
- * @since  15.08.2014
+ *  
+ * This is free software. Use it however you want.
  */
 
-class Kimai_Auth_Ldap extends Kimai_Auth_Abstract
-{
+class Kimai_Auth_Ldap extends Kimai_Auth_Abstract {
 
+    /** Your LDAP-Server */
+    private $LADP_SERVER = 'ldap://localhost';
+    /** Case-insensitivity of some Servers may confuse the case-sensitive-accounting system. */
+    private $LDAP_FORCE_USERNAME_LOWERCASE = true;
+    /** Preprends to username */
+    private $LDAP_USERNAME_PREFIX = 'cn=';
+    /** Appends to username */
+    private $LDAP_USERNAME_POSTFIX = ',dc=example,dc=com';
+    /** Accounts that sould be locally verified */
+    private $LDAP_LOCAL_ACCOUNTS = array('admin');
+    /** Automatically create a user in kimai if the login is successful. */
+    private $LDAP_USER_AUTOCREATE = true;
     /**
-     * Your LDAP-Server URI
-     *
-     * Remember that you can include ldaps scheme or a port number here
-     *
-     * @var string $host
+     * @var Kimai_Auth_Kimai|null
      */
-    protected $host = 'ldap://localhost';
+    private $kimaiAuth = null;
 
-    /**
-     * Bind-DN of a user that has read access to the ldap.
-     *
-     * Leave empty for anonymous bind
-     *
-     * @var string $bindDN
-     */
-    protected $bindDN = '';
-
-    /**
-     * The password to ue for non anonymous bind
-     *
-     * @var string $bindPW
-     */
-    protected $bindPW = '';
-
-    /**
-     * Search base to use
-     *
-     * @var string $searchBase
-     */
-    protected  $searchBase = 'dc=example,c=org';
-
-    /**
-     * The filter to use when searching for a user
-     *
-     * The string '%s' will be replaced by the string the user provided as username
-     *
-     * @var string $userFilter
-     */
-    protected $userFilter = 'uid=%s';
-
-    /**
-     * The filter to be used when checking group memberships
-     *
-     * The string %1$s will be replaced by the content of the attribute self::$usernameAttribute,
-     * the string %2$s will be replaced by the DN of the user
-     *
-     * @param string $groupFilter
-     */
-    protected $groupFilter = 'memberUid=%1$s';
-
-    /**
-     * Which LDAP-Attribute contains the username
-     *
-     * @param string $usernameAttribute
-     */
-    protected $usernameAttribute = 'uid';
-
-    /**
-     * Which LDAP-Attribute contains a readable username
-     *
-     * @param string $commonNameAttribute
-     */
-    protected $commonNameAttribute = 'cn';
-
-    /**
-     * Which LDAP-Attribute contains the group-id
-     *
-     * This is referenced by the entries of self::$allowedGroupIds
-     *
-     * @var string $groupidAttribute
-     */
-    protected $groupidAttribute = 'cn';
-
-    /**
-     * Which LDAP-Attribute contains the email-address
-     *
-     * This is just to set the correct mail-address for the user
-     *
-     * @var string $mailAttribute
-     */
-    protected $mailAttribute = 'mail';
-
-    /**
-     * Members of which LDAP-groups shall have access to kimai
-     *
-     * @var array $allowedGroupIds
-     */
-    protected $allowedGroupIds = array(
-        'kimai-access',
-    );
-
-    /**
-     * Shall we force usernames to lowercase?
-     *
-     * @var boolean $forceLowercase
-     */
-    protected $forceLowercase = true;
-
-    /**
-     * Accounts that sould be verified locally.
-     *
-     * All entries in this array will not be checked against the LDAP
-     *
-     * @var array $nonLdapAccounts
-     */
-    protected $nonLdapAcounts = array(
-        'admin'
-    );
-
-    /**
-     * Automatically create a user in kimai if the login is successful.
-     *
-     * @var boolean $autocreateUsers
-     */
-    protected $autocreateUsers = true;
-
-    /**
-     * The name of the default global role the user should be added to.
-     *
-     * @var string $defaultGlobalRoleName
-     */
-    protected $defaultGlobalRoleName = 'User';
-
-    /**
-     * Map of group=>role names for new users
-     *
-     * @var array $defaultGroupMemberships
-     */
-    protected $defaultGroupMemberships = array(
-        'Users' => 'User',
-    );
-
-    /**
-     * @var Kimai_Auth_Kimai $kimaiAuth
-     */
-    private $kimaiAuth;
-
-    /**
-     * {@inherit}
-     */
-    public function __construct($database = null, $kga = null)
-    {
-        if (! function_exists('ldap_bind')) {
-            throw new InvalidArgumentException('LDAP-Extension is not installed');
-        }
+    public function __construct($database = null, $kga = null) {
         parent::__construct($database, $kga);
         $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);
     }
 
-    /**
-     * {@inherit}
-     */
-    public function authenticate($username, $password, &$userId)
-    {
+    public function authenticate($username, $password, &$userId) {
         // Check if username should be authenticated locally
-        if (in_array($username, $this->nonLdapAcounts)) {
+        if (in_array($username, $this->LDAP_LOCAL_ACCOUNTS)) {
             return $this->kimaiAuth->authenticate($username, $password, $userId);
         }
 
+        // Check environment sanity
+        if (!function_exists('ldap_bind')) {
+            echo 'ldap is not installed!';
+            $userId = false;
+            return false;
+        }
 
-        if (! $username || ! $password) {
+        // Check if username is legal
+        $check_username = trim($username);
+
+        if (!$check_username || !trim($password) || ($this->LDAP_FORCE_USERNAME_LOWERCASE && strtolower($check_username) !== $check_username)) {
             $userId = false;
             return false;
         }
 
         // Connect to LDAP
-        $connect_result = ldap_connect($this->host);
-
+        $connect_result = ldap_connect($this->LADP_SERVER);
         if (!$connect_result) {
-            echo "Cannot connect to ", $this->host;
+            echo "Cannot connect to ", $this->LADP_SERVER;
             $userId = false;
             return false;
         }
 
         ldap_set_option($connect_result, LDAP_OPT_PROTOCOL_VERSION, 3);
 
-        // Bind to the ldap and query for the given userinformation.
-        if ($this->bindDN && $this->bindPW) {
-            $bindResult = ldap_bind($connect_result, $this->bindDN, $this->bindPW);
-        } else {
-            $bindResult = ldap_bind($connect_result);
-        }
+        // Try to bind. Binding means user and pwd are valid.
+        $bind_result = ldap_bind($connect_result, $this->LDAP_USERNAME_PREFIX . $check_username . $this->LDAP_USERNAME_POSTFIX, $password);
 
-        if (! $bindResult) {
-            echo sprintf(
-                "Can't bind to the LDAP with DN %s",
-                $this->bindDN
-            );
+        if (!$bind_result) {
+            // Nope!
             $userId = false;
             return false;
         }
-
-        $filter = sprintf($this->userFilter, $username);
-
-        $_ldapresults = ldap_search(
-            $connect_result,
-            $this->searchBase,
-            $filter,
-            array(
-                $this->usernameAttribute,
-                $this->mailAttribute,
-                $this->commonNameAttribute,
-            ),
-            0,
-            0,
-            10
-        );
-        if (! $_ldapresults) {
-            // The server returned no result-set at all.
-            echo "No user with that information found";
-            $userId = false;
-            return false;
-        }
-        if (1 > ldap_count_entries($connect_result, $_ldapresults)) {
-            // The returned result set contains no data.
-            echo "No user with that information found";
-            $userId = false;
-            return false;
-        }
-        if (1 < ldap_count_entries($connect_result, $_ldapresults)) {
-            // The returned result-set contains more than one person. So we
-            // can not be sure, that the user is unique.
-            echo "More than one user found with that information";
-            $userId = false;
-            return false;
-        }
-
-        $_results = ldap_get_entries($connect_result, $_ldapresults);
-        if (false === $_results) {
-            // The returned result-set could not be retrieved.
-            echo 'no result set found';
-            $userId = false;
-            return false;
-        }
-        // Empty the result set. We have the results in a variable so don't
-        // bother the server any more.
-        ldap_free_result ($_ldapresults);
-        $distinguishedName = $_results[0]['dn'];
-        $uidAttribute      = $_results[0][$this->usernameAttribute][0];
-        $emailAddress      = '';
-        $commonName        = '';
-        if (isset($_results[0][$this->mailAttribute][0])) {
-            $emailAddress = $_results[0][$this->mailAttribute][0];
-        }
-        if (isset($_results[0][$this->commonNameAttribute][0])) {
-            $commonName = $_results[0][$this->commonNameAttribute][0];
-        }
-
-        // Now lets try to bind with the returned distinguishedName and the
-        // provided passwort to the LDAP.
-        $link_id = @ldap_bind($connect_result, $distinguishedName, $password);
-        if (false === $link_id) {
-            echo 'Password and/or Username mismatch';
-            $userId = false;
-            return false;
-        }
-
-        // Check whether the user is member of one of the required LDAP-groups
-        $filter = sprintf($this->groupFilter, $uidAttribute, $distinguishedName);
-        $_ldapresults = ldap_search(
-            $connect_result,
-            $this->searchBase,
-            $filter,
-            array($this->groupidAttribute),
-            0,
-            0,
-            10
-        );
-        if (! $_ldapresults) {
-            // The server returned no result-set at all.
-            echo "No group for the user found";
-            $userId = false;
-            return false;
-        }
-        if (1 > ldap_count_entries($connect_result, $_ldapresults)) {
-            // The returned result set contains no data.
-            echo "No group for that user found";
-            $userId = false;
-            return false;
-        }
-        $_results = ldap_get_entries($connect_result, $_ldapresults);
-        if (false === $_results) {
-            // The returned result-set could not be retrieved.
-            echo 'no result set for groups found';
-            $userId = false;
-            return false;
-        }
-        ldap_free_result ( $_ldapresults );
-
-        $groups = array();
-        foreach ($_results as $result) {
-            $resultGroups = array();
-            for ($i = 0; $i < $result[$this->groupidAttribute]['count']; $i++) {
-                $resultGroups[] = $result[$this->groupidAttribute][$i];
-            }
-            $groups = array_merge($groups, $resultGroups);
-        }
-
-        if (! array_intersect($groups, $this->allowedGroupIds)) {
-            // The returned result-set could not be retrieved.
-            echo 'no valid groups found';
-            $userId = false;
-            return false;
-        }
+        ldap_unbind($connect_result);
 
         // User is authenticated. Does it exist in Kimai yet?
-        $check_username = $this->forceLowercase ? strtolower($uidAttribute) : $uidAttribute;
+        $check_username = $this->LDAP_FORCE_USERNAME_LOWERCASE ? strtolower($check_username) : $check_username;
 
         $userId = $this->database->user_name2id($check_username);
         if ($userId === false)  {
             // User does not exist (yet)
-            if ($this->autocreateUsers) {
-                // Create it!
-                $userId = $this->database->user_create(array(
-                    'name'         => $check_username,
-                    'globalRoleID' => $this->getDefaultGlobalRole(),
-                    'active'       => 1
-                ));
-
-                $this->database->setGroupMemberships($userId, $this->getDefaultGroups());
+            if ($this->LDAP_USER_AUTOCREATE) { // Create it!
+		$userId   = $this->database->user_create(array(
+			'name' => $check_username,
+			'globalRoleID' => $this->getDefaultGlobalRole(),
+			'active' => 1
+		));
+                $this->database->setGroupMemberships($userId,array($this->getDefaultGroups()));
 
                 // Set a password, to calm kimai down
                 $usr_data = array('password' => md5($this->kga['password_salt'] . md5(uniqid(rand(), true)) . $this->kga['password_salt']));
-                if ($emailAddress) {
-                    $usr_data['mail'] = $emailAddress;
-                }
-                if ($commonName) {
-                    $usr_data['alias'] = $commonName;
-                }
                 $this->database->user_edit($userId, $usr_data);
             } else {
                 $userId = false;
@@ -363,59 +97,7 @@ class Kimai_Auth_Ldap extends Kimai_Auth_Abstract
         return true;
     }
 
-    /**
-     * Get the default global role
-     *
-     * @return integer
-     */
-    public function getDefaultGlobalRole()
-    {
-        if ($this->defaultGlobalRoleName) {
-            $database = $this->getDatabase();
-
-            $roles = $database->global_roles();
-
-            foreach ($roles as $role) {
-                if ($role['name'] == $this->defaultGlobalRoleName) {
-                    return $role['globalRoleID'];
-                }
-            }
-        }
-
-        return parent::getDefaultGlobalRole();
-    }
-
-    /**
-     * Get a map of group=>role associations for new users
-     *
-     * @return array
-     */
-    public function getDefaultGroups()
-    {
-        $groups = array();
-        $roles  = array();
-        $map    = array();
-
-        $database = $this->getDatabase();
-        foreach ($database->membership_roles() as $role) {
-            $roles[$role['name']] = $role['membershipRoleID'];
-        }
-
-        foreach ($database->get_groups() as $group) {
-            $groups[$group['name']] = $group['groupID'];
-        }
-
-        foreach ($this->defaultGroupMemberships as $group => $role) {
-            if (! isset($groups[$group])) {
-                continue;
-            }
-            if (! isset($roles[$role])) {
-                continue;
-            }
-
-            $map[$groups[$group]] = $roles[$role];
-        }
-
-        return $map;
-    }
 }
+
+// There should be NO trailing whitespaces.
+?>

--- a/core/libraries/Kimai/Auth/Ldapadvanced.php
+++ b/core/libraries/Kimai/Auth/Ldapadvanced.php
@@ -1,0 +1,420 @@
+<?php
+
+/**
+ * Copyright (C) 2011 by Skaldrom Y. Sarg of oncode.info
+ * Copyright (C) 2014 by Andreas Heigl<andreas@heigl.org>
+ *
+ * This is free software. Use it however you want
+ *
+ * To activate this Authentication Adapter, add the following line to the
+ * ```includes/autoconf.php```-file:
+ *
+ *     $authenticator = 'ldapadvanced';
+ *
+ * To use your own config you can either overwrite the values given in this
+ * class or you extend this class with your own class just containing your own
+ * configuration. More Information is provided in the LDAP_README.md
+ *
+ * @author Andreas Heigl<andras@heigl.org>
+ * @since  15.08.2014
+ */
+
+class Kimai_Auth_Ldapadvanced extends Kimai_Auth_Abstract
+{
+
+    /**
+     * Your LDAP-Server URI
+     *
+     * Remember that you can include ldaps scheme or a port number here
+     *
+     * @var string $host
+     */
+    protected $host = 'ldap://localhost';
+
+    /**
+     * Bind-DN of a user that has read access to the ldap.
+     *
+     * Leave empty for anonymous bind
+     *
+     * @var string $bindDN
+     */
+    protected $bindDN = '';
+
+    /**
+     * The password to ue for non anonymous bind
+     *
+     * @var string $bindPW
+     */
+    protected $bindPW = '';
+
+    /**
+     * Search base to use
+     *
+     * @var string $searchBase
+     */
+    protected  $searchBase = 'dc=example,c=org';
+
+    /**
+     * The filter to use when searching for a user
+     *
+     * The string '%s' will be replaced by the string the user provided as username
+     *
+     * @var string $userFilter
+     */
+    protected $userFilter = 'uid=%s';
+
+    /**
+     * The filter to be used when checking group memberships
+     *
+     * The string %1$s will be replaced by the content of the attribute self::$usernameAttribute,
+     * the string %2$s will be replaced by the DN of the user
+     *
+     * @param string $groupFilter
+     */
+    protected $groupFilter = 'memberUid=%1$s';
+
+    /**
+     * Which LDAP-Attribute contains the username
+     *
+     * @param string $usernameAttribute
+     */
+    protected $usernameAttribute = 'uid';
+
+    /**
+     * Which LDAP-Attribute contains a readable username
+     *
+     * @param string $commonNameAttribute
+     */
+    protected $commonNameAttribute = 'cn';
+
+    /**
+     * Which LDAP-Attribute contains the group-id
+     *
+     * This is referenced by the entries of self::$allowedGroupIds
+     *
+     * @var string $groupidAttribute
+     */
+    protected $groupidAttribute = 'cn';
+
+    /**
+     * Which LDAP-Attribute contains the email-address
+     *
+     * This is just to set the correct mail-address for the user
+     *
+     * @var string $mailAttribute
+     */
+    protected $mailAttribute = 'mail';
+
+    /**
+     * Members of which LDAP-groups shall have access to kimai
+     *
+     * @var array $allowedGroupIds
+     */
+    protected $allowedGroupIds = array(
+        'kimai-access',
+    );
+
+    /**
+     * Shall we force usernames to lowercase?
+     *
+     * @var boolean $forceLowercase
+     */
+    protected $forceLowercase = true;
+
+    /**
+     * Accounts that sould be verified locally.
+     *
+     * All entries in this array will not be checked against the LDAP
+     *
+     * @var array $nonLdapAccounts
+     */
+    protected $nonLdapAcounts = array(
+        'admin'
+    );
+
+    /**
+     * Automatically create a user in kimai if the login is successful.
+     *
+     * @var boolean $autocreateUsers
+     */
+    protected $autocreateUsers = true;
+
+    /**
+     * The name of the default global role the user should be added to.
+     *
+     * @var string $defaultGlobalRoleName
+     */
+    protected $defaultGlobalRoleName = 'User';
+
+    /**
+     * Map of group=>role names for new users
+     *
+     * @var array $defaultGroupMemberships
+     */
+    protected $defaultGroupMemberships = array(
+        'Users' => 'User',
+    );
+
+    /**
+     * @var Kimai_Auth_Kimai $kimaiAuth
+     */
+    private $kimaiAuth;
+
+    /**
+     * {@inherit}
+     */
+    public function __construct($database = null, $kga = null)
+    {
+        if (! function_exists('ldap_bind')) {
+            throw new InvalidArgumentException('LDAP-Extension is not installed');
+        }
+        parent::__construct($database, $kga);
+        $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);
+    }
+
+    /**
+     * {@inherit}
+     */
+    public function authenticate($username, $password, &$userId)
+    {
+        // Check if username should be authenticated locally
+        if (in_array($username, $this->nonLdapAcounts)) {
+            return $this->kimaiAuth->authenticate($username, $password, $userId);
+        }
+
+
+        if (! $username || ! $password) {
+            $userId = false;
+            return false;
+        }
+
+        // Connect to LDAP
+        $connect_result = ldap_connect($this->host);
+
+        if (!$connect_result) {
+            echo "Cannot connect to ", $this->host;
+            $userId = false;
+            return false;
+        }
+
+        ldap_set_option($connect_result, LDAP_OPT_PROTOCOL_VERSION, 3);
+
+        // Bind to the ldap and query for the given userinformation.
+        if ($this->bindDN && $this->bindPW) {
+            $bindResult = ldap_bind($connect_result, $this->bindDN, $this->bindPW);
+        } else {
+            $bindResult = ldap_bind($connect_result);
+        }
+
+        if (! $bindResult) {
+            echo sprintf(
+                "Can't bind to the LDAP with DN %s",
+                $this->bindDN
+            );
+            $userId = false;
+            return false;
+        }
+
+        $filter = sprintf($this->userFilter, $username);
+
+        $_ldapresults = ldap_search(
+            $connect_result,
+            $this->searchBase,
+            $filter,
+            array(
+                $this->usernameAttribute,
+                $this->mailAttribute,
+                $this->commonNameAttribute,
+            ),
+            0,
+            0,
+            10
+        );
+        if (! $_ldapresults) {
+            // The server returned no result-set at all.
+            echo "No user with that information found";
+            $userId = false;
+            return false;
+        }
+        if (1 > ldap_count_entries($connect_result, $_ldapresults)) {
+            // The returned result set contains no data.
+            echo "No user with that information found";
+            $userId = false;
+            return false;
+        }
+        if (1 < ldap_count_entries($connect_result, $_ldapresults)) {
+            // The returned result-set contains more than one person. So we
+            // can not be sure, that the user is unique.
+            echo "More than one user found with that information";
+            $userId = false;
+            return false;
+        }
+
+        $_results = ldap_get_entries($connect_result, $_ldapresults);
+        if (false === $_results) {
+            // The returned result-set could not be retrieved.
+            echo 'no result set found';
+            $userId = false;
+            return false;
+        }
+        // Empty the result set. We have the results in a variable so don't
+        // bother the server any more.
+        ldap_free_result ($_ldapresults);
+        $distinguishedName = $_results[0]['dn'];
+        $uidAttribute      = $_results[0][$this->usernameAttribute][0];
+        $emailAddress      = '';
+        $commonName        = '';
+        if (isset($_results[0][$this->mailAttribute][0])) {
+            $emailAddress = $_results[0][$this->mailAttribute][0];
+        }
+        if (isset($_results[0][$this->commonNameAttribute][0])) {
+            $commonName = $_results[0][$this->commonNameAttribute][0];
+        }
+
+        // Now lets try to bind with the returned distinguishedName and the
+        // provided passwort to the LDAP.
+        $link_id = @ldap_bind($connect_result, $distinguishedName, $password);
+        if (false === $link_id) {
+            echo 'Password and/or Username mismatch';
+            $userId = false;
+            return false;
+        }
+
+        // Check whether the user is member of one of the required LDAP-groups
+        $filter = sprintf($this->groupFilter, $uidAttribute, $distinguishedName);
+        $_ldapresults = ldap_search(
+            $connect_result,
+            $this->searchBase,
+            $filter,
+            array($this->groupidAttribute),
+            0,
+            0,
+            10
+        );
+        if (! $_ldapresults) {
+            // The server returned no result-set at all.
+            echo "No group for the user found";
+            $userId = false;
+            return false;
+        }
+        if (1 > ldap_count_entries($connect_result, $_ldapresults)) {
+            // The returned result set contains no data.
+            echo "No group for that user found";
+            $userId = false;
+            return false;
+        }
+        $_results = ldap_get_entries($connect_result, $_ldapresults);
+        if (false === $_results) {
+            // The returned result-set could not be retrieved.
+            echo 'no result set for groups found';
+            $userId = false;
+            return false;
+        }
+        ldap_free_result ( $_ldapresults );
+
+        $groups = array();
+        foreach ($_results as $result) {
+            $resultGroups = array();
+            for ($i = 0; $i < $result[$this->groupidAttribute]['count']; $i++) {
+                $resultGroups[] = $result[$this->groupidAttribute][$i];
+            }
+            $groups = array_merge($groups, $resultGroups);
+        }
+
+        if (! array_intersect($groups, $this->allowedGroupIds)) {
+            // The returned result-set could not be retrieved.
+            echo 'no valid groups found';
+            $userId = false;
+            return false;
+        }
+
+        // User is authenticated. Does it exist in Kimai yet?
+        $check_username = $this->forceLowercase ? strtolower($uidAttribute) : $uidAttribute;
+
+        $userId = $this->database->user_name2id($check_username);
+        if ($userId === false)  {
+            // User does not exist (yet)
+            if ($this->autocreateUsers) {
+                // Create it!
+                $userId = $this->database->user_create(array(
+                    'name'         => $check_username,
+                    'globalRoleID' => $this->getDefaultGlobalRole(),
+                    'active'       => 1
+                ));
+
+                $this->database->setGroupMemberships($userId, $this->getDefaultGroups());
+
+                // Set a password, to calm kimai down
+                $usr_data = array('password' => md5($this->kga['password_salt'] . md5(uniqid(rand(), true)) . $this->kga['password_salt']));
+                if ($emailAddress) {
+                    $usr_data['mail'] = $emailAddress;
+                }
+                if ($commonName) {
+                    $usr_data['alias'] = $commonName;
+                }
+                $this->database->user_edit($userId, $usr_data);
+            } else {
+                $userId = false;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the default global role
+     *
+     * @return integer
+     */
+    public function getDefaultGlobalRole()
+    {
+        if ($this->defaultGlobalRoleName) {
+            $database = $this->getDatabase();
+
+            $roles = $database->global_roles();
+
+            foreach ($roles as $role) {
+                if ($role['name'] == $this->defaultGlobalRoleName) {
+                    return $role['globalRoleID'];
+                }
+            }
+        }
+
+        return parent::getDefaultGlobalRole();
+    }
+
+    /**
+     * Get a map of group=>role associations for new users
+     *
+     * @return array
+     */
+    public function getDefaultGroups()
+    {
+        $groups = array();
+        $roles  = array();
+        $map    = array();
+
+        $database = $this->getDatabase();
+        foreach ($database->membership_roles() as $role) {
+            $roles[$role['name']] = $role['membershipRoleID'];
+        }
+
+        foreach ($database->get_groups() as $group) {
+            $groups[$group['name']] = $group['groupID'];
+        }
+
+        foreach ($this->defaultGroupMemberships as $group => $role) {
+            if (! isset($groups[$group])) {
+                continue;
+            }
+            if (! isset($roles[$role])) {
+                continue;
+            }
+
+            $map[$groups[$group]] = $roles[$role];
+        }
+
+        return $map;
+    }
+}


### PR DESCRIPTION
This PR replaces the currently available LDAP-Adapter with a highly configurable one. 

The new LDAP-Adapter can be used as authentication adapter for any LDAP-Server. Usage and Configuration are described in the acompanying LDAP_README.md file

Applying this LDAP-Adapter is a clear BC-Break as current configurations will not work any more. On the other hand, after an update the administrator has to reconfigure the LDAP-Adapter in any case as it has been replaced during the upgrade. Therefore that should not be an issue!
