### PR TITLE
Adds a testing framework

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,0 +1,11 @@
+set -x
+if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ] || [ "$TRAVIS_PHP_VERSION" = 'hhvm-nightly' ] ; then
+    curl -sS https://getcomposer.org/installer > composer-installer.php
+    hhvm composer-installer.php
+    hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar update --prefer-source
+    hhvm -v ResourceLimit.SocketDefaultTimeout=30 -v Http.SlowQueryThreshold=30000 composer.phar install --dev --prefer-source
+else
+    composer self-update
+    composer update --prefer-source
+    composer install --dev --prefer-source
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: php
+
+php:
+ - 5.3.3
+ - 5.3
+ - 5.4
+ - 5.5
+ - 5.6
+ - hhvm
+ - hhvm-nightly
+
+before_script:
+ - ./.travis.install.sh
+
+script:
+ - ./vendor/bin/phpunit --configuration=phpunit.xml.travis
+
+matrix:
+ allow_failures:
+  - php: hhvm
+  - php: hhvm-nightly
+

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,17 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php" : ">=5.3.0"
+    },
+    "require-dev" : {
         "phpunit/phpunit" : "3.7.*"
-    }
+    },
+    "autoload": {
+        "classmap" : [
+            "core/libraries"
+        ]
+    },
+    "include-path": [
+        "core/libraries"
+    ]
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./test/bootstrap.php">
+    <testsuite name="Kimai Application-Test Suite">
+        <directory>./test/library</directory>
+    </testsuite>
+    <groups>
+        <exclude>
+            <group>disable</group>
+        </exclude>
+    </groups>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">./core/libraries</directory>
+            <exclude>
+                <directory>./core/libraries/Zend</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <!-- 
+            Adapt these paths to your special needs 
+        -->
+        <log type="coverage-html" target="doc/coverage" charset="UTF-8"
+             yui="true" highlight="false"
+             lowUpperBound="35" highLowerBound="70"/>
+        <!-- log type="coverage-xml" target="path/to/coverage.xml"/-->
+        <!-- log type="graphviz" target="path/to/logfile.dot"/-->
+        <!-- log type="json" target="path/to/phpunit/logfile.json"/-->
+        <!-- log type="metrics-xml" target="path/to/phpunit/metrics.xml"/-->
+        <!-- log type="plain" target="path/to/phpunit/logfile.txt"/-->
+        <!-- log type="pmd-xml" target="path/to/phpunit/pmd.xml" cpdMinLines="5" cpdMinMatches="70"/-->
+        <!-- log type="tap" target="path/to/phpunit/logfile.tap"/-->
+        <!-- log type="test-xml" target="path/to/phpunit/logfile.xml" logIncompleteSkipped="false"/-->
+        <!-- log type="testdox-html" target="path/to/phpunit/testdox.html"/-->
+        <!-- log type="testdox-text" target="path/to/phpunit/testdox.txt"/-->
+    </logging>
+</phpunit>

--- a/phpunit.xml.travis
+++ b/phpunit.xml.travis
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./test/bootstrap.php">
+    <testsuite name="Kimai Application-Test Suite">
+        <directory>./test/library</directory>
+    </testsuite>
+    <groups>
+        <exclude>
+            <group>disable</group>
+        </exclude>
+    </groups>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">./core/libraries/Kimai</directory>
+            <exclude>
+                <directory>./core/libraries/Zend</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <logging>
+        <!-- 
+            Adapt these paths to your special needs 
+        -->
+        <!--log type="coverage-html" target="doc/coverage" charset="UTF-8"
+             yui="true" highlight="false"
+             lowUpperBound="35" highLowerBound="70"/-->
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
+        <!-- log type="coverage-xml" target="path/to/coverage.xml"/-->
+        <!-- log type="graphviz" target="path/to/logfile.dot"/-->
+        <!-- log type="json" target="path/to/phpunit/logfile.json"/-->
+        <!-- log type="metrics-xml" target="path/to/phpunit/metrics.xml"/-->
+        <!-- log type="plain" target="path/to/phpunit/logfile.txt"/-->
+        <!-- log type="pmd-xml" target="path/to/phpunit/pmd.xml" cpdMinLines="5" cpdMinMatches="70"/-->
+        <!-- log type="tap" target="path/to/phpunit/logfile.tap"/-->
+        <!-- log type="test-xml" target="path/to/phpunit/logfile.xml" logIncompleteSkipped="false"/-->
+        <!-- log type="testdox-html" target="path/to/phpunit/testdox.html"/-->
+        <!-- log type="testdox-text" target="path/to/phpunit/testdox.txt"/-->
+    </logging>
+</phpunit>

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/**
+ * @author heiglandreas
+ */
+
+// TODO: check include path
+ini_set ( 'date.timezone', 'Europe/Berlin' );
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+}
+
+ini_set('include_path', ini_get('include_path')
+                        . PATH_SEPARATOR . __DIR__ . '/library'
+                        . PATH_SEPARATOR . __DIR__ . '/../core/libraries'
+);
+
+class UnitTestHelper
+{
+    /**
+     * Access protected or private methods
+     *
+     * use the following code to access any protected or private class method
+     * $obj = new MyClass();
+     * $method = UnitTestHelper::getMethod($obj, 'nameOfMethod');
+     * $result = $method->invoke($obj,'param1','param2');
+     *
+     * @param Object|string $obj
+     * @param string $name
+     *
+     * @return method
+     */
+    public static function getMethod($obj, $name) {
+        $class = new ReflectionClass($obj);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method;
+    }
+}


### PR DESCRIPTION
This PR adds some phpunit-files to make testing easier as well as adding some files to enable testing via TravisCI.

Tests can be placed inside the `test`-folder and a simple `phpunit` will then execute them. You might have to execute `composer dump-autoload` to get the autoloading right.

The Repository can also be added to travis-CI.org and on every commit the tests are executed on all PHP-Versions including hhvm. The Code-Coverage only includes the coverage of the tested files. All not tested files are not included!
