### PR TITLE
Fixed user edit dialog always showing a rate. (fixes #395)

### DIFF
--- a/core/extensions/ki_adminpanel/templates/scripts/floaters/edituser.php
+++ b/core/extensions/ki_adminpanel/templates/scripts/floaters/edituser.php
@@ -205,7 +205,7 @@
 
                     <li>
                         <label for="rate"><?php echo $this->kga['lang']['rate']?>:</label>
-                        <input class="formfield" type="text" id="rate" name="rate" value="<?php echo $this->escape(number_format($this->user_details['rate'], 2, $this->kga['conf']['decimalSeparator'],""))?>" />
+                        <input class="formfield" type="text" id="rate" name="rate" value="<?php echo $this->escape(str_replace('.', $this->kga['conf']['decimalSeparator'], $this->user_details['rate']));?>" />
                     </li>
 
 


### PR DESCRIPTION
number_format always returns a number, even for empty values. Therefore
use the same formatting method here as in every other floater.
