### PR TITLE
Rerecorded entries are always not cleared. (fixes #421)

### DIFF
--- a/core/extensions/ki_timesheets/processor.php
+++ b/core/extensions/ki_timesheets/processor.php
@@ -95,6 +95,7 @@ switch ($axAction) {
         $timeSheetEntry['start'] = time();
         $timeSheetEntry['end'] = 0;
         $timeSheetEntry['duration'] = 0;
+        $timeSheetEntry['cleared'] = 0;
 
         $errors = array();
         timesheetAccessAllowed($timeSheetEntry,'edit',$errors);


### PR DESCRIPTION
It makes no sense to rerecord an entry which will immediately be
cleared.
