### PR TITLE
Fixed wide floaters in the nordic skin.

### DIFF
--- a/core/skins/nordic/floater.css
+++ b/core/skins/nordic/floater.css
@@ -1,5 +1,5 @@
 #floater {
-	width:35em !important;
+	width:35em;
 	border:2px solid #048;
 	position: absolute;
 	padding:5px;


### PR DESCRIPTION
It is necessary for the timesheet entry floater to be wider because the
input fields are wider. Otherwise the textareas are misplaces. See
http://forum.kimai.org/index.php?topic=1945.msg7739#msg7739
