### PR TITLE
Fixed starting multiple recordings. (fixes #419)

### DIFF
--- a/core/extensions/ki_timesheets/init.php
+++ b/core/extensions/ki_timesheets/init.php
@@ -57,10 +57,14 @@ else
 $view->total = $total;
 
 // Get the array of timesheet entries.
-if (isset($kga['customer']))
+if (isset($kga['customer'])) {
   $timeSheetEntries = $database->get_timeSheet($in,$out,null,array($kga['customer']['customerID']),null,1);
-else
+  $view->latest_running_entry = null;
+} else {
   $timeSheetEntries = $database->get_timeSheet($in,$out,array($kga['user']['userID']),null,null,1);
+  $view->latest_running_entry = $database->get_latest_running_entry();
+}
+
 if (count($timeSheetEntries)>0) {
     $view->timeSheetEntries = $timeSheetEntries;
 } else {

--- a/core/extensions/ki_timesheets/processor.php
+++ b/core/extensions/ki_timesheets/processor.php
@@ -365,6 +365,7 @@ switch ($axAction) {
         } else {
             $view->timeSheetEntries = 0;
         }
+        $view->latest_running_entry = $database->get_latest_running_entry();
         $view->total = Format::formatDuration($database->get_duration($in,$out,$filterUsers,$filterCustomers,$filterProjects,$filterActivities));
 
         $ann = $database->get_time_users($in,$out,$filterUsers,$filterCustomers,$filterProjects,$filterActivities);

--- a/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/core/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -1,7 +1,5 @@
 <?php
 
-$latest_running_row_index = -1;
-
 if ($this->timeSheetEntries)
 {
     ?>
@@ -69,7 +67,6 @@ if ($this->timeSheetEntries)
         <?php if ($row['end']): ?>
             <tr id="timeSheetEntry<?php echo $row['timeEntryID']?>" class="<?php echo $this->cycle(array("odd","even"))->next()?>">
         <?php else: ?>
-            <?php if ($latest_running_row_index == -1) { $latest_running_row_index = $rowIndex; } ?>
             <tr id="timeSheetEntry<?php echo $row['timeEntryID']?>" class="<?php echo $this->cycle(array("odd","even"))->next()?> active">
         <?php endif; ?>
 
@@ -233,14 +230,14 @@ else
     lists_update_annotations(parseInt($('#gui div.ki_timesheet').attr('id').substring(7)),ts_user_annotations,ts_customer_annotations,ts_project_annotations,ts_activity_annotations);
     $('#display_total').html(ts_total);
     
-  <?php if ($latest_running_row_index == -1): ?>
+  <?php if ($this->latest_running_entry == null): ?>
     updateRecordStatus(false);
   <?php else: ?>
 
-    updateRecordStatus(<?php echo $this->timeSheetEntries[$latest_running_row_index]['timeEntryID']?>,<?php echo $this->timeSheetEntries[$latest_running_row_index]['start']?>,
-                             <?php echo $this->timeSheetEntries[$latest_running_row_index]['customerID']?>,'<?php echo $this->jsEscape($this->timeSheetEntries[$latest_running_row_index]['customerName'])?>',
-                             <?php echo $this->timeSheetEntries[$latest_running_row_index]['projectID']?> ,'<?php echo $this->jsEscape($this->timeSheetEntries[$latest_running_row_index]['projectName'])?>',
-                             <?php echo $this->timeSheetEntries[$latest_running_row_index]['activityID']?>,'<?php echo $this->jsEscape($this->timeSheetEntries[$latest_running_row_index]['activityName'])?>');
+    updateRecordStatus(<?php echo $this->latest_running_entry['timeEntryID']?>,<?php echo $this->latest_running_entry['start']?>,
+                             <?php echo $this->latest_running_entry['customerID']?>,'<?php echo $this->jsEscape($this->latest_running_entry['customerName'])?>',
+                             <?php echo $this->latest_running_entry['projectID']?> ,'<?php echo $this->jsEscape($this->latest_running_entry['projectName'])?>',
+                             <?php echo $this->latest_running_entry['activityID']?>,'<?php echo $this->jsEscape($this->latest_running_entry['activityName'])?>');
   <?php endif; ?>
 
     function timesheet_hide_column(name) {

--- a/core/libraries/Kimai/Database/Abstract.php
+++ b/core/libraries/Kimai/Database/Abstract.php
@@ -486,6 +486,14 @@ abstract class Kimai_Database_Abstract {
   public abstract function get_current_recordings($userID);
 
   /**
+   * Return the latest running entry with all information required for the buzzer.
+   *
+   * @return array with all data
+   * @author sl
+   */
+  public abstract function get_latest_running_entry();
+
+  /**
   * Returns the data of a certain time record
   *
   * @param array $timeSheetEntryID  timeSheetEntryID of the record

--- a/core/libraries/Kimai/Database/Mysql.php
+++ b/core/libraries/Kimai/Database/Mysql.php
@@ -1773,6 +1773,37 @@ class Kimai_Database_Mysql extends Kimai_Database_Abstract {
   }
 
   /**
+   * Return the latest running entry with all information required for the buzzer.
+   *
+   * @return array with all data
+   * @author sl
+   */
+  public function get_latest_running_entry() {
+
+    $p = $this->kga['server_prefix'];
+
+		$table = $this->getTimeSheetTable();
+		$projectTable = $this->getProjectTable();
+		$activityTable = $this->getActivityTable();
+		$customerTable = $this->getCustomerTable();
+		
+    $select = "SELECT $table.*, $projectTable.name AS projectName, $customerTable.name AS customerName, $activityTable.name AS activityName, $customerTable.customerID AS customerID
+          FROM $table
+              JOIN $projectTable USING(projectID)
+              JOIN $customerTable USING(customerID)
+              JOIN $activityTable USING(activityID)";
+
+    $result = $this->conn->Query("$select WHERE end = 0 AND userID = ".$this->kga['user']['userID']." ORDER BY timeEntryID DESC LIMIT 1");
+
+    if (! $result) {
+      return null;
+    }
+    else {
+      return $this->conn->RowArray(0,MYSQL_ASSOC);
+    }
+  }
+
+  /**
   * Returns the data of a certain time record
   *
   * @param array $timeEntryID  timeEntryID of the record


### PR DESCRIPTION
It was possible to start multiple recordings by applying a filter so
that the current recording was not shown anymore. This worked because
the running recording was determined from the list of shown entries.

The fix is to always check in the database if a recording is running and
return its information.
