### PR TITLE
Prevent bypassing permissions using filters.

### DIFF
--- a/core/extensions/ki_budget/processor.php
+++ b/core/extensions/ki_budget/processor.php
@@ -35,23 +35,23 @@ if ($filters[0] == "") {
 	$filterUsers = explode(':',$filters[0]);
 }
 
-if ($filters[1] == "") {
-	$filterCustomers = array();
-} else {
-	$filterCustomers = explode(':',$filters[1]);
-}
+$filterCustomers = array_map(function($customer) {
+  return $customer['customerID'];
+}, $database->get_customers($kga['user']['groups']));
+if ($filters[1] != "")
+  $filterCustomers = array_intersect($filterCustomers, explode(':',$filters[1]));
 
-if ($filters[2] == "") {
-	$filterProjects = array();
-} else {
-	$filterProjects = explode(':',$filters[2]);
-}
+$filterProjects = array_map(function($project) {
+  return $project['projectID'];
+}, $database->get_projects($kga['user']['groups']));
+if ($filters[2] != "")
+  $filterProjects = array_intersect($filterProjects, explode(':',$filters[2]));
 
-if (!isset($filters[3]) || $filters[3] == "") {
-	$filterActivities = array();
-} else {
-	$filterActivities = explode(':',$filters[3]);
-}
+$filterActivities = array_map(function($activity) {
+  return $activity['activityID'];
+}, $database->get_activities($kga['user']['groups']));
+if ($filters[3] != "")
+  $filterActivities = array_intersect($filterActivities, explode(':',$filters[3]));
 
 // if no userfilter is set, set it to current user
 if (isset($kga['user']) && count($filterUsers) == 0) {

--- a/core/extensions/ki_expenses/processor.php
+++ b/core/extensions/ki_expenses/processor.php
@@ -90,15 +90,17 @@ switch ($axAction) {
       else
         $filterUsers = explode(':',$filters[0]);
 
-      if ($filters[1] == "")
-        $filterCustomers = array();
-      else
-        $filterCustomers = explode(':',$filters[1]);
+      $filterCustomers = array_map(function($customer) {
+        return $customer['customerID'];
+      }, $database->get_customers($kga['user']['groups']));
+      if ($filters[1] != "")
+        $filterCustomers = array_intersect($filterCustomers, explode(':',$filters[1]));
 
-      if ($filters[2] == "")
-        $filterProjects = array();
-      else
-        $filterProjects = explode(':',$filters[2]);
+      $filterProjects = array_map(function($project) {
+        return $project['projectID'];
+      }, $database->get_projects($kga['user']['groups']));
+      if ($filters[2] != "")
+        $filterProjects = array_intersect($filterProjects, explode(':',$filters[2]));
 
       // if no userfilter is set, set it to current user
       if (isset($kga['user']) && count($filterUsers) == 0)

--- a/core/extensions/ki_export/processor.php
+++ b/core/extensions/ki_export/processor.php
@@ -68,20 +68,23 @@ if ($axAction == 'export_csv'  ||
   else
     $filterUsers = explode(':',$filters[0]);
 
-  if ($filters[1] == "")
-    $filterCustomers = array();
-  else
-    $filterCustomers = explode(':',$filters[1]);
+  $filterCustomers = array_map(function($customer) {
+    return $customer['customerID'];
+  }, $database->get_customers($kga['user']['groups']));
+  if ($filters[1] != "")
+    $filterCustomers = array_intersect($filterCustomers, explode(':',$filters[1]));
 
-  if ($filters[2] == "")
-    $filterProjects = array();
-  else
-    $filterProjects = explode(':',$filters[2]);
+  $filterProjects = array_map(function($project) {
+    return $project['projectID'];
+  }, $database->get_projects($kga['user']['groups']));
+  if ($filters[2] != "")
+    $filterProjects = array_intersect($filterProjects, explode(':',$filters[2]));
 
-  if ($filters[3] == "")
-    $filterActivities = array();
-  else
-    $filterActivities = explode(':',$filters[3]);
+  $filterActivities = array_map(function($activity) {
+    return $activity['activityID'];
+  }, $database->get_activities($kga['user']['groups']));
+  if ($filters[3] != "")
+    $filterActivities = array_intersect($filterActivities, explode(':',$filters[3]));
 
   // if no userfilter is set, set it to current user
   if (isset($kga['user']) && count($filterUsers) == 0)

--- a/core/extensions/ki_timesheets/processor.php
+++ b/core/extensions/ki_timesheets/processor.php
@@ -337,20 +337,23 @@ switch ($axAction) {
         else
           $filterUsers = explode(':',$filters[0]);
 
-        if ($filters[1] == "")
-          $filterCustomers = array();
-        else
-          $filterCustomers = explode(':',$filters[1]);
+        $filterCustomers = array_map(function($customer) {
+          return $customer['customerID'];
+        }, $database->get_customers($kga['user']['groups']));
+        if ($filters[1] != "")
+          $filterCustomers = array_intersect($filterCustomers, explode(':',$filters[1]));
 
-        if ($filters[2] == "")
-          $filterProjects = array();
-        else
-          $filterProjects = explode(':',$filters[2]);
+        $filterProjects = array_map(function($project) {
+          return $project['projectID'];
+        }, $database->get_projects($kga['user']['groups']));
+        if ($filters[2] != "")
+          $filterProjects = array_intersect($filterProjects, explode(':',$filters[2]));
 
-        if ($filters[3] == "")
-          $filterActivities = array();
-        else
-          $filterActivities = explode(':',$filters[3]);
+        $filterActivities = array_map(function($activity) {
+          return $activity['activityID'];
+        }, $database->get_activities($kga['user']['groups']));
+        if ($filters[3] != "")
+          $filterActivities = array_intersect($filterActivities, explode(':',$filters[3]));
 
         // if no userfilter is set, set it to current user
         if (isset($kga['user']) && count($filterUsers) == 0)


### PR DESCRIPTION
It was possible to see customers, projects or activities you have no
permission to see by filtering by a user which has entries for any of
these.

This is now prevented by always including the allowed customers,
projects and activities when querying the database. When a filter is
applied the intersection between the set of all allowed IDs and the set
of the selected IDs is used.
