### PR TITLE
Recordings can always be stopped. (fixes #455)

### DIFF
--- a/core/js/main.js
+++ b/core/js/main.js
@@ -356,9 +356,9 @@ function startRecord(projectID,activityID,userID) {
 // stops the current recording when the stop-buzzer is hidden
 //
 function stopRecord() {
-    $("#timeSheetTable>table>tbody>tr>td>a.stop>img").attr("src","../skins/"+skin+"/grfx/loading13_red.gif");
-    $("#timeSheetTable>table>tbody>tr:first-child>td").css( "background-color", "#F00" );
-    $("#timeSheetTable>table>tbody>tr:first-child>td").css( "color", "#FFF" );
+    $("#timeSheetTable>table>tbody>tr#timeSheetEntry"+currentRecording+">td>a.stop>img").attr("src","../skins/"+skin+"/grfx/loading13_red.gif");
+    $("#timeSheetTable>table>tbody>tr#timeSheetEntry"+currentRecording+">td").css( "background-color", "#F00" );
+    $("#timeSheetTable>table>tbody>tr#timeSheetEntry"+currentRecording+">td").css( "color", "#FFF" );
     show_selectors();
     $.post("processor.php", { axAction: "stopRecord", axValue: 0, id: currentRecording},
         function(){
@@ -412,8 +412,8 @@ function buzzer() {
 
 
   if (currentRecording > -1) {
-      currentRecording=0;
       stopRecord();
+      currentRecording=0;
     } else {
         setTimeframe(undefined,new Date());
         startRecord(selected_project,selected_activity,userID);


### PR DESCRIPTION
Up until now the stopRecord call always used an ID of 0 to identify the
timesheet entry to stop. The database layer had a special logic for this
case to use the latest (most recent created) timesheet entry. If for any
reason another entry was created for that user this entry selected
instead of the one we wanted to stop. The entry was actually not changed
because an additional check ensures that only running entries are
stopped by stopRecord.

I also fixed highlighting the correct row to indicate that a recording
is being stopped.
