### PR TITLE
Don't leak project names and activities in exports.

### DIFF
--- a/core/extensions/ki_export/processor.php
+++ b/core/extensions/ki_export/processor.php
@@ -68,30 +68,40 @@ if ($axAction == 'export_csv'  ||
   else
     $filterUsers = explode(':',$filters[0]);
 
-  $filterCustomers = array_map(function($customer) {
-    return $customer['customerID'];
-  }, $database->get_customers($kga['user']['groups']));
+  if (isset($kga['customer'])) {
+    $filterCustomers = $kga['customer']['customerID'];
+    $filterProjects = array_map(function($project) {
+      return $project['projectID'];
+    }, $database->get_projects_by_customer($kga['customer']['customerID']));
+    $filterActivities = array_map(function($activity) {
+      return $activity['activityID'];
+    }, $database->get_activities_by_customer($kga['customer']['customerID']));
+  }
+  else {
+    $filterCustomers = array_map(function($customer) {
+      return $customer['customerID'];
+    }, $database->get_customers($kga['user']['groups']));
+    $filterProjects = array_map(function($project) {
+      return $project['projectID'];
+    }, $database->get_projects($kga['user']['groups']));
+    $filterActivities = array_map(function($activity) {
+      return $activity['activityID'];
+    }, $database->get_activities($kga['user']['groups']));
+
+    // if no userfilter is set, set it to current user
+    if (isset($kga['user']) && count($filterUsers) == 0)
+      array_push($filterUsers,$kga['user']['userID']);
+  }
+
   if ($filters[1] != "")
     $filterCustomers = array_intersect($filterCustomers, explode(':',$filters[1]));
 
-  $filterProjects = array_map(function($project) {
-    return $project['projectID'];
-  }, $database->get_projects($kga['user']['groups']));
   if ($filters[2] != "")
     $filterProjects = array_intersect($filterProjects, explode(':',$filters[2]));
 
-  $filterActivities = array_map(function($activity) {
-    return $activity['activityID'];
-  }, $database->get_activities($kga['user']['groups']));
   if ($filters[3] != "")
     $filterActivities = array_intersect($filterActivities, explode(':',$filters[3]));
 
-  // if no userfilter is set, set it to current user
-  if (isset($kga['user']) && count($filterUsers) == 0)
-    array_push($filterUsers,$kga['user']['userID']);
-    
-  if (isset($kga['customer']))
-    $filterCustomers = array($kga['customer']['customerID']);
 }
 
 


### PR DESCRIPTION
A previous fix (f950fe92863942060ec0dfd7061a0219a89f90d0) fetched all
customers, projects and activities from the database for the groups of
the current user. For customers this did not work and returned a list of
all customers, projects and activities.

For the list of customers this was not an issue since it's later set to
only be the logged in customer.

For the list of activities this was no problem either because this list
was intersected with the selected activities and then only used for
filtering.

For the list of projects this was a problem. It was used to display the
names of the selected projects in several export formats.

This fix now determines the list of projects and activities the customer
may actually see first.

Fixes: #473
