### PR TITLE
[BUGFIX] export: columns toggling (resolves #524)

### DIFF
--- a/core/extensions/ki_export/private_func.php
+++ b/core/extensions/ki_export/private_func.php
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
  */
-$all_column_headers = array('date', 'from', 'to', 'time', 'dec_time', 'rate', 'wage', 'customer', 'project', 'activity', 'comment', 'location', 'trackingNumber', 'user', 'cleared', 'description');
+$all_column_headers = array('date', 'from', 'to', 'time', 'dec_time', 'rate', 'wage', 'budget', 'approved', 'status', 'billable', 'customer', 'project', 'activity', 'description', 'comment', 'location', 'trackingNumber', 'user', 'cleared');
 // Determine if the expenses extension is used.
 $expense_ext_available = false;
 if (file_exists('../ki_expenses/private_db_layer_' . $kga['server_conn'] . '.php')) {


### PR DESCRIPTION
New columns had been added [here](https://github.com/kimai/kimai/commit/d41e4d2ce90dd3aab7bb4b57166489a173ee1411#diff-339996afd6e2dd55d62911b1223ef67eR46)
but this change was is discord with the column header definition
in this file.
I now added those missing columns.
