### PR TITLE
 [FEATURE] excel export: formatting (resolves #526)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ autoconf.php
 .settings
 .idea/
 .DS_Store
+/bin/

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "time": "2013-08-03",
     "version": "0.9.3-beta1",
     "config": {
-        "vendor-dir": "core/libraries",
+        "vendor-dir": "core/libraries/composer",
         "bin-dir": "bin"
     },
     "authors": [
@@ -36,22 +36,5 @@
     },
     "include-path": [
         "core/libraries"
-    ],
-    "repositories": [{
-	    "type": "package",
-	    "package": {
-	        "name": "PHPOffice/PHPExcel",
-	        "version": "1.8.0",
-	        "source": {
-	            "url": "https://github.com/PHPOffice/PHPExcel.git",
-	            "type": "git",
-	            "reference": "1.8.0"
-	        },
-	        "autoload": {
-	            "psr-0": {
-	                "PHPExcel": "Classes/"
-	            }
-	        }
-	    }
-	}]
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,10 @@
     "minimum-stability": "dev",
     "time": "2013-08-03",
     "version": "0.9.3-beta1",
+    "config": {
+        "vendor-dir": "core/libraries",
+        "bin-dir": "bin"
+    },
     "authors": [
         {
             "name": "Severin Leonhardt",
@@ -19,7 +23,8 @@
         }
     ],
     "require": {
-        "php" : ">=5.3.0"
+        "php" : ">=5.3.0",
+        "PHPOffice/PHPExcel": "1.8.*"
     },
     "require-dev" : {
         "phpunit/phpunit" : "3.7.*"
@@ -31,5 +36,22 @@
     },
     "include-path": [
         "core/libraries"
-    ]
+    ],
+    "repositories": [{
+	    "type": "package",
+	    "package": {
+	        "name": "PHPOffice/PHPExcel",
+	        "version": "1.8.0",
+	        "source": {
+	            "url": "https://github.com/PHPOffice/PHPExcel.git",
+	            "type": "git",
+	            "reference": "1.8.0"
+	        },
+	        "autoload": {
+	            "psr-0": {
+	                "PHPExcel": "Classes/"
+	            }
+	        }
+	    }
+	}]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,23 +4,69 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b198142555beec8e15fd39f56888d8d4",
-    "content-hash": "271c0fe98e2a0906e9eca343be7cd718",
+    "hash": "7b8c1f3941652ccb045ccec950e7c4af",
+    "content-hash": "054658d1ae81762c611e45ebfeb98bd9",
     "packages": [
         {
-            "name": "PHPOffice/PHPExcel",
-            "version": "1.8.0",
+            "name": "phpoffice/phpexcel",
+            "version": "1.8.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PHPExcel.git",
-                "reference": "1.8.0"
+                "reference": "a27e053354adf9f7fc327f6c8b79041ff129eb83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PHPExcel/zipball/a27e053354adf9f7fc327f6c8b79041ff129eb83",
+                "reference": "a27e053354adf9f7fc327f6c8b79041ff129eb83",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.2|^7.0"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "2.*"
             },
             "type": "library",
             "autoload": {
                 "psr-0": {
                     "PHPExcel": "Classes/"
                 }
-            }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "http://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "http://rootslabs.net"
+                }
+            ],
+            "description": "PHPExcel - OpenXML - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "http://phpexcel.codeplex.com",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "time": "2015-12-31 00:16:34"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,456 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "b198142555beec8e15fd39f56888d8d4",
+    "content-hash": "271c0fe98e2a0906e9eca343be7cd718",
+    "packages": [
+        {
+            "name": "PHPOffice/PHPExcel",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PHPExcel.git",
+                "reference": "1.8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPExcel": "Classes/"
+                }
+            }
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "1.2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": ">=1.3.0@stable",
+                "phpunit/php-text-template": ">=1.2.0@stable",
+                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@dev"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-09-02 10:13:14"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2015-06-21 08:01:12"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHP/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2014-03-03 05:10:30"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "3.7.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpunit/php-code-coverage": "~1.2",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.1",
+                "phpunit/php-timer": "~1.0",
+                "phpunit/phpunit-mock-objects": "~1.2",
+                "symfony/yaml": "~2.0"
+            },
+            "require-dev": {
+                "pear-pear.php.net/pear": "1.9.4"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "composer/bin/phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.7.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "",
+                "../../symfony/yaml/"
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "http://www.phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2014-10-17 09:04:17"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "1.2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "c39c4511c3b007539eb170c32cbc2af49a07351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/c39c4511c3b007539eb170c32cbc2af49a07351a",
+                "reference": "c39c4511c3b007539eb170c32cbc2af49a07351a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": ">=1.1.1@stable"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*@dev"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPUnit/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2014-02-16 12:43:56"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "2.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "cee3fdda8184add20a13eb666295dfd72e8031bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cee3fdda8184add20a13eb666295dfd72e8031bd",
+                "reference": "cee3fdda8184add20a13eb666295dfd72e8031bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-12-28 13:12:56"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0"
+    },
+    "platform-dev": []
+}

--- a/core/extensions/ki_export/processor.php
+++ b/core/extensions/ki_export/processor.php
@@ -276,24 +276,16 @@ switch ($axAction) {
     case 'export_xls':
 
         $database->user_set_preferences(array(
-          'decimal_separator' => $_REQUEST['decimal_separator'],
           'reverse_order' => isset($_REQUEST['reverse_order'])?1:0),
           'ki_export.xls.');      
        
         $exportData = export_get_data($in,$out,$filterUsers,$filterCustomers,$filterProjects,$filterActivities,false,$reverse_order,$default_location,$filter_cleared,$filter_type,false,$filter_refundable);
-        for ($i=0;$i<count($exportData);$i++) {
-          $exportData[$i]['decimalDuration'] = str_replace(".",$_REQUEST['decimal_separator'],$exportData[$i]['decimalDuration']);
-          $exportData[$i]['rate'] = str_replace(".",$_REQUEST['decimal_separator'],$exportData[$i]['rate']);
-          $exportData[$i]['wage'] = str_replace(".",$_REQUEST['decimal_separator'],$exportData[$i]['wage']);
-        }
         $view->exportData = count($exportData)>0?$exportData:0;
 
         $view->columns = $columns;
         $view->custom_timeformat = $timeformat;
         $view->custom_dateformat = $dateformat;
 
-        header("Content-Disposition:attachment;filename=export.xls");
-        header("Content-Type: application/vnd.ms-excel");
         echo $view->render("formats/excel.php");
     break;
 

--- a/core/extensions/ki_export/templates/scripts/floaters/export_XLS.php
+++ b/core/extensions/ki_export/templates/scripts/floaters/export_XLS.php
@@ -24,10 +24,6 @@
             <fieldset>
                 <ul>
                     <li>
-                        <label for="decimal_separator"><?php echo $this->kga['lang']['decimal_separator'] ?>:</label>
-                        <input type="text" value="<?php echo $this->escape($this->kga['conf']['decimalSeparator']) ?>" name="decimal_separator" id="decimal_separator" size="1"/>
-                    </li>
-                    <li>
                         <label for="reverse_order"><?php echo $this->kga['lang']['export_extension']['reverse_order'] ?>:</label>
                         <input type="checkbox" value="true" name="reverse_order" id="reverse_order" <?php if ($this->prefs['reverse_order']): ?> checked="checked" <?php endif; ?>/>
                     </li>

--- a/core/extensions/ki_export/templates/scripts/formats/excel.php
+++ b/core/extensions/ki_export/templates/scripts/formats/excel.php
@@ -1,245 +1,30 @@
-<html xmlns:o="urn:schemas-microsoft-com:office:office" 
-xmlns:x="urn:schemas-microsoft-com:office:excel" 
-xmlns="http://www.w3.org/TR/REC-html40"> 
+<?php
+/**
+ * This file is part of
+ * Kimai - Open Source Time Tracking // http://www.kimai.org
+ * (c) 2006-2009 Kimai-Development-Team
+ *
+ * Kimai is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; Version 3, 29 June 2007
+ *
+ * Kimai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
+ */
 
-<head> 
-<meta http-equiv=Content-Type content="text/html; charset=utf-8">
-<style> 
-.date { 
-mso-number-format:"Short Date"; 
-} 
-.time { 
-mso-number-format:"h\:mm\:ss\;\@"; 
-} 
-.duration {
-mso-number-format:"h\:mm\;\@";
-}
-.decimal {
-mso-number-format:Fixed;
-}
-</style> 
-<!--[if gte mso 9]><xml>
- <x:ExcelWorkbook>
-  <x:ExcelWorksheets>
-   <x:ExcelWorksheet>
-    <x:Name>Tabelle1</x:Name>
-    <x:WorksheetOptions>
-     <x:DefaultColWidth>10</x:DefaultColWidth>
-     <x:Selected/>
-     <x:Panes>
-      <x:Pane>
-       <x:Number>3</x:Number>
-       <x:ActiveRow>4</x:ActiveRow>
-       <x:ActiveCol>3</x:ActiveCol>
-      </x:Pane>
-     </x:Panes>
-     <x:ProtectContents>False</x:ProtectContents>
-     <x:ProtectObjects>False</x:ProtectObjects>
-     <x:ProtectScenarios>False</x:ProtectScenarios>
-    </x:WorksheetOptions>
-   </x:ExcelWorksheet>
-  </x:ExcelWorksheets>
- </x:ExcelWorkbook>
-</xml><![endif]-->
-</head> 
+/**
+ * View to render export excel
+ * uses PHPExcel
+ * @author Florian Lentsch <office@florian-lentsch.at>
+ */
 
-<body> 
-<table> 
-<thead><tr> 
-<!-- column headers -->
-<?php if (isset($this->columns['date'])):         ?> <td><?php echo $this->kga['lang']['datum']?></td>       <?php endif; ?>
-<?php if (isset($this->columns['from'])):         ?> <td><?php echo $this->kga['lang']['in']?></td>          <?php endif; ?>
-<?php if (isset($this->columns['to'])):           ?> <td><?php echo $this->kga['lang']['out']?></td>         <?php endif; ?>
-<?php if (isset($this->columns['time'])):         ?> <td><?php echo $this->kga['lang']['time']?></td>        <?php endif; ?>
-<?php if (isset($this->columns['dec_time'])):     ?> <td><?php echo $this->kga['lang']['timelabel']?></td>   <?php endif; ?>
-<?php if (isset($this->columns['rate'])):         ?> <td><?php echo $this->kga['lang']['rate']?></td>        <?php endif; ?>
-<?php if (isset($this->columns['wage'])):         ?> <td><?php echo $this->kga['currency_name']?>}</td>      <?php endif; ?>
-<?php if (isset($this->columns['budget'])):       ?> <td><?php echo $this->kga['lang']['budget']?></td>      <?php endif; ?>
-<?php if (isset($this->columns['approved'])):     ?> <td><?php echo $this->kga['lang']['approved']?></td>    <?php endif; ?>
-<?php if (isset($this->columns['status'])):       ?> <td><?php echo $this->kga['lang']['status']?></td>      <?php endif; ?>
-<?php if (isset($this->columns['billable'])):     ?> <td><?php echo $this->kga['lang']['billable']?></td>    <?php endif; ?>
-<?php if (isset($this->columns['customer'])):     ?> <td><?php echo $this->kga['lang']['customer']?></td>    <?php endif; ?>
-<?php if (isset($this->columns['project'])):      ?> <td><?php echo $this->kga['lang']['project']?></td>     <?php endif; ?>
-<?php if (isset($this->columns['activity'])):     ?> <td><?php echo $this->kga['lang']['activity']?></td>    <?php endif; ?>
-<?php if (isset($this->columns['description'])):  ?> <td><?php echo $this->kga['lang']['description']?></td> <?php endif; ?>
-<?php if (isset($this->columns['comment'])):      ?> <td><?php echo $this->kga['lang']['comment']?></td>     <?php endif; ?>
-<?php if (isset($this->columns['location'])):     ?> <td><?php echo $this->kga['lang']['location']?></td>   <?php endif; ?>
-<?php if (isset($this->columns['trackingNumber'])):   ?> <td><?php echo $this->kga['lang']['trackingNumber']?></td>  <?php endif; ?>
-<?php if (isset($this->columns['user'])):         ?> <td><?php echo $this->kga['lang']['username']?></td>    <?php endif; ?>
-<?php if (isset($this->columns['cleared'])):      ?> <td><?php echo $this->kga['lang']['cleared']?></td>     <?php endif; ?>
-</tr> 
-</thead> 
-<?php foreach($this->exportData as $row): ?>
-<tr> 
+require_once dirname(__FILE__) . '/../helpers/ExcelExporter.php';
 
-<?php if (isset($this->columns['date'])): ?>
-                    <td class=date>
-                        <?php  if ($this->custom_dateformat)
-                            echo $this->escape(strftime($this->custom_dateformat,$row['time_in']));
-                          else
-                            echo $this->escape(strftime($this->kga['date_format'][1], $row['time_in']));
-                        ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['from'])): ?>
-                    <td align=right class=time>
-                        <?php  if ($this->custom_timeformat)
-                            echo $this->escape(strftime($this->custom_timeformat,$row['time_in']));
-                          else
-                            echo $this->escape(strftime("%H:%M", $row['time_in']));
-                        ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['to'])): ?>
-                    <td align=right class=time>
-                    
-<?php if ($row['time_out']): ?>
-                        <?php  if ($this->custom_timeformat)
-                            echo $this->escape(strftime($this->custom_timeformat,$row['time_out']));
-                          else
-                            echo $this->escape(strftime("%H:%M", $row['time_in']));
-                        ?>
-<?php else: ?>      
-                        &ndash;&ndash;:&ndash;&ndash;
-<?php endif; ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['time'])): ?>
-                    <td align=right class=duration>
-                        <?php echo $row['duration'] ? $row['formattedDuration'] : "&ndash;:&ndash;&ndash;" ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['dec_time'])): ?>
-                    <td align=right class=decimal>
-                        <?php echo $row['decimalDuration'] ?$row['decimalDuration'] : "&ndash;:&ndash;&ndash;" ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['rate'])): ?>
-                    <td align=right class=decimal>
-                            <?php echo $row['rate'] ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['wage'])): ?>
-                    <td align=right class=decimal>
-                        <?php echo $row['wage']? $row['wage'] : "&ndash;" ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['budget'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['budget']); ?>
-                    </td>
-<?php endif; ?>
-
-
-
-<?php if (isset($this->columns['approved'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['approved']); ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['status'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['status']); ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['billable'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['billable']); ?>%
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['customer'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['customerName']); ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['project'])): ?>
-                    <td>
-                            <?php echo $this->escape($row['projectName']); ?>
-                    </td>
-<?php endif; ?>
-
-
-
-<?php if (isset($this->columns['activity'])): ?>
-                    <td>
-                            <?php echo $this->escape($row['activityName']); ?> 
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['description'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['description']); ?>%
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['comment'])): ?>
-                    <td>
-                        <?php echo str_replace("\n", "&#10;", $this->escape($row['comment'])); ?>
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['location'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['location']); ?>
-                        
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['trackingNumber'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['trackingNumber']); ?>
-                        
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['user'])): ?>
-                    <td>
-                        <?php echo $this->escape($row['username']); ?>
-                        
-                    </td>
-<?php endif; ?>
-
-
-<?php if (isset($this->columns['cleared'])): ?>
-          <td>
-                      <?php if ($row['cleared']) echo "cleared" ?>
-          </td>
-<?php endif; ?>
-          
-
-                </tr>
-               
-<?php endforeach; ?>
-
-</table> 
-
-</body> 
-</html>  
- 
+$excel = new Kimai_Export_ExcelExporter();
+$excel->render($this->kga, $this->exportData, $this->columns, $this->custom_timeformat);
+?>

--- a/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
+++ b/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
@@ -213,10 +213,14 @@ class Kimai_Export_ExcelExporter extends PHPExcel {
 				$type = array_key_exists('type', $fieldConf) ? $fieldConf['type'] : 'string';
 				switch ($type) {
 					case 'date':
-						$formattedValue =  PHPExcel_Shared_Date::PHPToExcel($data[$key]);
+						$date = date('Y-m-d H:i:s +0000', $data[$key]);
+						$tstamp = date('U', strtotime($date));
+						$formattedValue =  PHPExcel_Shared_Date::PHPToExcel($tstamp);
 						break;
 					case 'time':
-						$formattedValue =  PHPExcel_Shared_Date::PHPToExcel($data[$key]);
+						$date = date('Y-m-d H:i:s +0000', $data[$key]);
+						$tstamp = date('U', strtotime($date));
+						$formattedValue =  PHPExcel_Shared_Date::PHPToExcel($tstamp);
 						break;
 					case 'duration':
 						$formattedValue = (((date('H', $data[$key]) - 1) * 3600) + (date('i', $data[$key]) * 60) + date('s', $data[$key])) / 86400;

--- a/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
+++ b/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
@@ -1,0 +1,517 @@
+<?php 
+/**
+ * This file is part of
+ * Kimai - Open Source Time Tracking // http://www.kimai.org
+ * (c) 2006-2009 Kimai-Development-Team
+ *
+ * Kimai is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; Version 3, 29 June 2007
+ *
+ * Kimai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// autoload composer packages:
+require 'autoload.php';
+
+/**
+ * Helper class to export time sheets as Excel file
+ * @author Florian Lentsch <office@florian-lentsch.at>
+ *
+ */
+class Kimai_Export_ExcelExporter extends PHPExcel {
+	
+	/**
+	 * Column configuration:
+	 * <field name as in $this->columns_dict> => [
+	 * 		'fieldName' => <field name as in $this->exportData_arr - defaults to the same field name as in $this->columns>
+	 * 		'type' => <determines field formatting - one of string (default), date, time, duration, floatDurationHours, boolean, percent, and text>
+	 * 		'langLabel' => <key for $this->kga['lang'] - defaults to the same as the field name in $this->columns>
+	 * 		'sum' => boolean - if true, sums will be generated for this field
+	 * ]
+	 * @var array
+	 */
+	protected static $COLUMN_CONFIG = array(
+			'date' => array('fieldName' => 'time_in', 'type' => 'date', 'langLabel' => 'datum'),
+			'from' => array('fieldName' => 'time_in', 'type' => 'time', 'langLabel' => 'in'),
+			'to' => array('fieldName' => 'time_out', 'type' => 'time', 'langLabel' => 'out'),
+			'time' => array('fieldName' => 'duration', 'type' => 'duration', 'sum' => true),
+			'dec_time' => array('fieldName' => 'duration', 'type' => 'floatDurationHours', 'langLabel' => 'timelabel', 'sum' => true),
+			'rate' => array('type' => 'float'),
+			'wage' => array('type' => 'money', 'sum' => true),
+			'budget' => array('type' => 'money', 'sum' => true),
+			'approved' => array('type' => 'boolean'),
+			'billable' => array('type' => 'percent'),
+			'customer' => array('fieldName' => 'customerName'),
+			'project' => array('fieldName' => 'projectName'),
+			'activity' => array('fieldName' => 'activityName'),
+			'description' => array('type' => 'text'),
+			'comment' => array('type' => 'text'),
+			'user' => array('fieldName' => 'username', 'langLabel' => 'username'),
+			'cleared' => array('type' => 'boolean'),
+	);
+	
+	/**
+	 * vertical offset for data rows
+	 * @var integer
+	 */
+	const EXCEL_HEADER_OFFSET = 1;
+	
+	/**
+	 * Kimai Global Array
+	 * @var array
+	 */
+	public $kga;
+	
+	/**
+	 * the data rows to be exported
+	 * @var array
+	 */
+	public $exportData_arr;
+	
+	/**
+	 * dictionary
+	 * 	value: column name as in extensions/ki_export/templates/scripts/main.php
+	 * 	key: true if active, else false
+	 * @var array
+	 */
+	public $columns_dict;
+	
+	/**
+	 * strftime format string for fields of type time
+	 * @var string
+	 */
+	public $customTimeformat;
+	
+	/**
+	 * contains names (as in $this->columns_dict) of active columns
+	 * @var array
+	 */
+	protected $activeColumns_arr;
+	
+	/**
+	 * the first (and only) worksheet
+	 * @var PHPExcel_Worksheet
+	 */
+	protected $sheet;
+	
+	/**
+	 * excel format string for fields of type date
+	 * @var string
+	 */
+	protected $dateFormat;
+	
+	/**
+	 * excel format string for fields of type time
+	 * @var string
+	 */
+	protected $timeFormat;
+	
+	/**
+	 * true, if there are any active columns with sums, else false 
+	 * @var boolean
+	 */
+	protected $anySumsWereAdded = false;
+	
+	/**
+	 * generates an .xlsx file containing time sheets to be exported
+	 * the file will be sent to the browser for download/viewing
+	 * @param array $kga Kimai Global Array
+	 * @param array $exportData_arr the data rows to be exported
+	 * @param array $columns_dict dictionary of columns: column name => active (true/false) 
+	 * @param string $customTimeformat strftime format string for fields of type time (for dates $this->kga['conf']['date_format_1'] will be used)
+	 */
+	public function render(array $kga, array $exportData_arr, array $columns_dict, $customTimeformat) {
+		$this->kga = $kga;
+		$this->exportData_arr = $exportData_arr;
+		$this->columns_dict = $columns_dict;
+		$this->customTimeformat = $customTimeformat;
+		
+		$this->initialize();
+		$this->writeHeaders();
+		$this->writeDataRows();
+		$this->writeSums();
+		
+		$this->doLayouting();
+		
+		$this->renderExcel();
+	}
+	
+	/**
+	 * renders the excel and sends it to the browser
+	 */
+	protected function renderExcel() {
+		header('Content-Disposition: attachment;filename="export.xlsx"');
+		header('Cache-Control: max-age=0');
+		header("Content-Type: application/vnd.ms-excel");
+		$writer = PHPExcel_IOFactory::createWriter($this, 'Excel2007');
+		$writer->setPreCalculateFormulas(true);
+		$writer->save('php://output');
+	}
+	
+	/**
+	 * initial PHPExcel settings; build $this->activeColumns_arr  
+	 */
+	protected function initialize() {
+		$this->sheet = $this->setActiveSheetIndex(0);
+		$this->sheet->setTitle("Export");
+		
+		// build $this->activeColumns_arr:
+		$columns_dict = $this->columns_dict;
+		unset($columns_dict['cleared']); // <- cannot be toggled - so for now, don't show it at all
+		$this->activeColumns_arr = array_keys(array_filter($columns_dict, function($active) {
+			return $active;
+		}));
+		
+		// convert strftime format to Excel date/time formats:
+		$this->dateFormat = str_replace('%', '', $this->kga['conf']['date_format_1']); // preferring the configurable value over $this->dateformat (hardcoded)
+		$this->dateFormat = str_replace('y', 'yy', $this->dateFormat);
+		$this->dateFormat = str_replace('Y', 'yyyy', $this->dateFormat);
+		$this->dateFormat = str_replace('d', 'dd', $this->dateFormat);
+		$this->dateFormat = str_replace('a', 'ddd', $this->dateFormat);
+		$this->dateFormat = str_replace('w', 'dddd', $this->dateFormat);
+		$this->dateFormat = str_replace('m', 'mm', $this->dateFormat);
+		
+		$this->timeFormat = str_replace('%', '', $this->customTimeformat); // $this->custom_timeformat is currently hardcoded - but it's better than nothing
+		$this->timeFormat = str_replace('H', 'hh', $this->timeFormat);
+		$this->timeFormat = str_replace('M', 'mm', $this->timeFormat);
+		$this->timeFormat = str_replace('S', 'ss', $this->timeFormat);
+		$this->timeFormat = str_replace('I', 'hh', $this->timeFormat);
+		$this->timeFormat = str_replace('p', 'AM/PM', $this->timeFormat);
+	}
+	
+	/**
+	 * write the headers for all active columns
+	 */
+	protected function writeHeaders() {
+		foreach($this->activeColumns_arr as $x => $columnName) {
+			if(array_key_exists($columnName, self::$COLUMN_CONFIG) && array_key_exists('langLabel', self::$COLUMN_CONFIG[$columnName])) {
+				$columnName = self::$COLUMN_CONFIG[$columnName]['langLabel'];
+			}
+		
+			$columnLabel = $this->kga['lang'][$columnName];
+			$this->sheet->setCellValue(self::excelAddr($x, 0), $columnLabel);
+		}
+	}
+	
+	/**
+	 * write the data rows for all active columns
+	 */
+	protected function writeDataRows() {
+		foreach($this->exportData_arr as $y => $data) {
+			foreach($this->activeColumns_arr as $x => $columnName) {
+				$curAddr = self::excelAddr($x, $y + self::EXCEL_HEADER_OFFSET);
+				$fieldConf = array_key_exists($columnName, self::$COLUMN_CONFIG) ? self::$COLUMN_CONFIG[$columnName] : array();
+				$key = array_key_exists('fieldName', $fieldConf) ? $fieldConf['fieldName'] : $columnName;
+		
+				$type = array_key_exists('type', $fieldConf) ? $fieldConf['type'] : 'string';
+				switch ($type) {
+					case 'date':
+						$formattedValue =  PHPExcel_Shared_Date::PHPToExcel($data[$key]);
+						break;
+					case 'time':
+						$formattedValue =  PHPExcel_Shared_Date::PHPToExcel($data[$key]);
+						break;
+					case 'duration':
+						$formattedValue = (((date('H', $data[$key]) - 1) * 3600) + (date('i', $data[$key]) * 60) + date('s', $data[$key])) / 86400;
+						break;
+					case 'float':
+					case 'percent':
+					case 'money':
+						// once PHP < 5.3 support is dropped, we could use numfmt_parse instead:
+						$formattedValue = floatval($data[$key]);
+						break;
+					case 'floatDurationHours':
+						$formattedValue = floatval($data[$key]) / 3600;
+						break;
+					case 'boolean':
+						$formattedValue = $data[$key] ? $this->kga['lang']['yes'] : $this->kga['lang']['no'];
+						break;
+					default:
+						$formattedValue = trim($data[$key]);
+						break;
+				}
+		
+				$this->sheet->setCellValue($curAddr, $formattedValue);
+			}
+		}
+	}
+	
+	/**
+	 * write sums for active columns
+	 * only if configured in self::$COLUMN_CONFIG 
+	 */
+	protected function writeSums() {
+		for($x = count($this->activeColumns_arr) - 1; $x >= 0; $x--) {
+			$columnName = $this->activeColumns_arr[$x];
+			$fieldConf = array_key_exists($columnName, self::$COLUMN_CONFIG) ? self::$COLUMN_CONFIG[$columnName] : array();
+			$doSum = array_key_exists('sum', $fieldConf) ? $fieldConf['sum'] : false;
+			$curAddr = self::excelAddr($x, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr));
+		
+			if (!$doSum) {
+				if ($x == 0 && $this->anySumsWereAdded) {
+					$this->sheet->setCellValue($curAddr, $this->kga['lang']['total']);
+				}
+				
+				continue;
+			}
+		
+			$this->anySumsWereAdded = true;
+			$this->sheet->setCellValue($curAddr, "=SUM(" . self::excelRange($x, self::EXCEL_HEADER_OFFSET, $x, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr) - 1) . ")");
+		}
+	}
+	
+	/**
+	 * do layouting (cell borders, font styles, background colors,
+	 * cell sizing, page setup)
+	 */
+	protected function doLayouting() {
+		$this->formatDataRowsByType();
+		$this->addCellBorders();
+		$this->formatHeaders();
+		$this->formatSums();
+		
+		// auto-width columns:
+		for ($x = 0; $x < count($this->activeColumns_arr); $x++) {
+			$this->sheet->getColumnDimension(self::excelColumnAddr($x))->setAutoSize(true);
+		}
+		
+		// auto-height rows:
+		foreach($this->sheet->getRowDimensions() as $rd) {
+			$rd->setRowHeight(-1);
+		}
+		
+		// fixed header when scrolling down in Excel:
+		$this->sheet->freezePane(self::excelAddr(0, self::EXCEL_HEADER_OFFSET));
+		
+		
+		$pageSetup = $this->sheet->getPageSetup();
+		
+		// when printing, show header on every page:
+		$pageSetup->setRowsToRepeatAtTop(self::EXCEL_HEADER_OFFSET); 
+		
+		// increase chances that page can be printed out without seperating a row's data over more than one page:
+		$pageSetup->setOrientation(PHPExcel_Worksheet_PageSetup::ORIENTATION_LANDSCAPE);
+	}
+	
+	/**
+	 * cell formatting (number/text/date ...) as 
+	 * configured in self::$COLUMN_CONFIG
+	 */
+	protected function formatDataRowsByType() {
+		foreach($this->activeColumns_arr as $x => $columnName) {
+			$fieldConf = array_key_exists($columnName, self::$COLUMN_CONFIG) ? self::$COLUMN_CONFIG[$columnName] : array();
+			$key = array_key_exists('fieldName', $fieldConf) ? $fieldConf['fieldName'] : $columnName;
+			$doSum = array_key_exists('sum', $fieldConf) ? $fieldConf['sum'] : false;
+			$curRange = self::excelRange($x, self::EXCEL_HEADER_OFFSET, $x, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr) - ($doSum ? 0 : 1));
+		
+			$type = array_key_exists('type', $fieldConf) ? $fieldConf['type'] : 'string';
+			switch($type) {
+				case 'date':
+					$this->sheet->getStyle($curRange)
+					->getNumberFormat()
+					->setFormatCode($this->dateFormat);
+					break;
+				case 'time':
+					$this->sheet->getStyle($curRange)
+					->getNumberFormat()
+					->setFormatCode($this->timeFormat);
+					break;
+				case 'duration':
+					$this->sheet->getStyle($curRange)
+					->getNumberFormat()
+					->setFormatCode('[h]:mm');
+					break;
+				case 'floatDurationHours':
+				case 'float':
+					$this->sheet->getStyle($curRange)
+					->getNumberFormat()
+					->setFormatCode(PHPExcel_Style_NumberFormat::FORMAT_NUMBER_00);
+					break;
+				case 'percent':
+					$this->sheet->getStyle($curRange)
+					->getNumberFormat()
+					->setFormatCode(PHPExcel_Style_NumberFormat::FORMAT_NUMBER_00 . " %");
+					break;
+				case 'money':
+					$this->sheet->getStyle($curRange)
+					->getNumberFormat()
+					->setFormatCode("{$this->kga['conf']['currency_sign']} " . PHPExcel_Style_NumberFormat::FORMAT_NUMBER_00);
+					break;
+				case 'text':
+					$this->sheet->getStyle($curRange)
+					->getAlignment()->setWrapText(true);
+					break;
+			}
+		}
+	}
+	
+	/**
+	 * add cell borders
+	 */
+	protected function addCellBorders() {
+		// thin lines on the outline, hair lines for all the interior cell borders:
+		$this->sheet->getStyle(self::excelRange(0, 0, count($this->activeColumns_arr) - 1, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr) - ($this->anySumsWereAdded ? 0 : 1)))
+			->applyFromArray(array(
+					'borders'	 => array(
+							'allborders' => array(
+									'style'	 => PHPExcel_Style_Border::BORDER_HAIR,
+									'color' => array('argb' => 'FFAAAAAA'),
+							),
+							'outline' => array(
+									'style'	 => PHPExcel_Style_Border::BORDER_THIN,
+									'color' => array('argb' => 'FF000000'),
+							),
+					),
+		));
+			
+		// date seperating borders:
+		$curDate = NULL;
+		foreach($this->exportData_arr as $y => $data) {
+			$date = date('Y-m-d', $data['time_in']);
+			if ($date !== $curDate) {
+				if ($curDate !== NULL) {
+					$this->sheet->getStyle(self::excelRange(0, $y + self::EXCEL_HEADER_OFFSET, count($this->activeColumns_arr) - 1, $y + self::EXCEL_HEADER_OFFSET))
+					->applyFromArray(array(
+							'borders'	 => array(
+									'top' => array(
+											'color' => array('argb' => 'FF000000'),
+									),
+							),
+					));
+				}
+		
+				$curDate = $date;
+			}
+		}
+	}
+	
+	/**
+	 * format the headers (additional cell borders,
+	 * background color, alignment)
+	 */
+	protected function formatHeaders() {
+		// bold & thin cell border outline:		
+		$this->sheet->getStyle(self::excelRange(0, 0, count($this->activeColumns_arr) - 1, 0))
+			->applyFromArray(array(
+					'font' => array(
+							'bold' => 'true'
+					),
+					'borders'	 => array(
+							'outline' => array(
+									'style'	 => PHPExcel_Style_Border::BORDER_THIN,
+									'color' => array('argb' => 'FF000000'),
+							),
+					),
+		));
+		
+		// gray background color:
+		$this->sheet->getStyle(self::excelRange(0, 0, count($this->activeColumns_arr) - 1, 0))
+			->getFill()->setFillType(PHPExcel_Style_Fill::FILL_SOLID)
+			->getStartColor()->setARGB('FFEEEEEE');
+		
+		// align headers for numeric fields right:
+		foreach($this->activeColumns_arr as $x => $columnName) {
+			$fieldConf = array_key_exists($columnName, self::$COLUMN_CONFIG) ? self::$COLUMN_CONFIG[$columnName] : array();
+			$type = array_key_exists('type', $fieldConf) ? $fieldConf['type'] : 'string';
+			$curAddr = self::excelAddr($x, 0);
+		
+			switch($type) {
+				case 'date':
+				case 'time':
+				case 'duration':
+				case 'float':
+				case 'floatDurationHours':
+				case 'money':
+					$this->sheet->getStyle($curAddr)
+						->applyFromArray(array(
+						'alignment'	 => array(
+						'horizontal' => PHPExcel_Style_Alignment::HORIZONTAL_RIGHT,
+						),
+					));
+					break;
+				default:
+					$this->sheet->getStyle($curAddr)
+						->applyFromArray(array(
+						'alignment'	 => array(
+						'horizontal' => PHPExcel_Style_Alignment::HORIZONTAL_LEFT,
+						),
+					));
+					break;
+			}
+		}
+	}
+	
+	/**
+	 * format the sums row if there are any sums
+	 * (borders and background color)
+	 */
+	protected function formatSums() {
+		if (!$this->anySumsWereAdded) {
+			return;
+		}
+		
+		$this->sheet->getStyle(self::excelRange(0, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr), count($this->activeColumns_arr) - 1, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr)))
+			->applyFromArray(array(
+					'font' => array(
+							'bold' => 'true'
+					),
+					'borders'	 => array(
+							'outline' => array(
+									'style'	 => PHPExcel_Style_Border::BORDER_THIN,
+									'color' => array('argb' => 'FF000000'),
+							),
+					),
+			));
+		
+		$this->sheet->getStyle(self::excelRange(0, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr), count($this->activeColumns_arr) - 1, self::EXCEL_HEADER_OFFSET + count($this->exportData_arr)))
+			->getFill()->setFillType(PHPExcel_Style_Fill::FILL_SOLID)
+			->getStartColor()->setARGB('FFEEEEEE');
+		
+	}
+	
+	
+	/**
+	 * get excel column letter by index (e.g. '2' becomes 'C')
+	 * using this over PHPExcels built-in methods, because
+	 * they are partly 1-based instead of 0-based
+	 * @param integer $n column index
+	 * @return string excel column letter
+	 */
+	protected static function excelColumnAddr($n) {
+		$r = '';
+		for ($i = 1; $n >= 0 && $i < 10; $i++) {
+			$r = chr(0x41 + ($n % pow(26, $i) / pow(26, $i - 1))) . $r;
+			$n -= pow(26, $i);
+		}
+		return $r;
+	}
+	
+	/**
+	 * get excel field address by supplying coordinates (e.g. '1/1' becomes 'B2')
+	 * @param integer $x horizontal coordinate
+	 * @param integer $y vertical coordinate
+	 * @return string excel field address
+	 */
+	protected static function excelAddr($x,$y) {
+		return self::excelColumnAddr($x).($y+1);
+	}	
+	
+	/**
+	 * get excel field range by supplying coordinates
+	 * @param integer first corner's horizontal coordinate
+	 * @param integer first corner's vertical coordinate
+	 * @param integer second corner's horizontal coordinate
+	 * @param integer second corner's vertical coordinate
+	 * @return string excel field range
+	 */
+	protected static function excelRange($x1,$y1,$x2,$y2) {
+		return self::excelAddr($x1,$y1).':'.self::excelAddr($x2,$y2);
+	}
+}

--- a/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
+++ b/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
@@ -18,7 +18,7 @@
  */
 
 // autoload composer packages:
-require 'autoload.php';
+require 'composer/autoload.php';
 
 /**
  * Helper class to export time sheets as Excel file

--- a/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
+++ b/core/extensions/ki_export/templates/scripts/helpers/ExcelExporter.php
@@ -294,7 +294,7 @@ class Kimai_Export_ExcelExporter extends PHPExcel {
 		$pageSetup = $this->sheet->getPageSetup();
 		
 		// when printing, show header on every page:
-		$pageSetup->setRowsToRepeatAtTop(self::EXCEL_HEADER_OFFSET); 
+		$pageSetup->setRowsToRepeatAtTopByStartAndEnd(1, self::EXCEL_HEADER_OFFSET); 
 		
 		// increase chances that page can be printed out without seperating a row's data over more than one page:
 		$pageSetup->setOrientation(PHPExcel_Worksheet_PageSetup::ORIENTATION_LANDSCAPE);

--- a/core/libraries/.gitignore
+++ b/core/libraries/.gitignore
@@ -1,5 +1,1 @@
 /composer/
-/PHPOffice/
-/phpunit/
-/symfony/
-/autoload.php

--- a/core/libraries/.gitignore
+++ b/core/libraries/.gitignore
@@ -1,0 +1,5 @@
+/composer/
+/PHPOffice/
+/phpunit/
+/symfony/
+/autoload.php


### PR DESCRIPTION
added formatting and sum formulas to the excel export
uses `PHPExcel` (included using composer) to generate xlsx files

To try it out, you will need to run `composer install`.

@simonschaufi 

> I would prefer if the library would be included via composer but then it is not in the desired folder (core/libraries). With composer you can make sure you always get a working version. Let's figure out how we can place it there without too much trouble.

I just had to add `vendor-dir: "core/libraries"`.

It would be pretty tricky, if you'd want to have `phpunit` installed to `vendor/`, but everything else to core/libraries/. (There is https://github.com/mnsami/composer-custom-directory-installer, but that didn't work for me...)

I don't think this is necessary though. I added `bin-dir: "bin"`, so now you can run phpunit by entering `bin/phpunit`. People who just want to use kimai for production will run `composer install --no-dev` anyway.

In the long run I'd suggest making all the packages under `core/libraries` composer packages. (Than you could change the `.gitignore` file there to ignore everything but itself.) If not possible, you should maybe add an extra subpath and change composers `vendor-dir` to `core/libraries/composer`

By the way, I added composer.lock to git as it [should be in there](https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file).
