### PR TITLE
change gmdate for a public function timelenght

### DIFF
--- a/core/extensions/ki_export/base_export_pdf.php
+++ b/core/extensions/ki_export/base_export_pdf.php
@@ -79,6 +79,18 @@ class BasePDF extends TCPDF {
     $minutes = floor($seconds/60);
     return sprintf('% 2d:%02d', $hours, $minutes);
   }
+  
+  /**
+   * calculate time in hh:mm from duration lenght in second
+   * @param lenght in second $duration
+   * @return string time in format hh:mm
+   */
+  public function timeLength($duration)
+  {
+      $m=(($duration-$s) / 60) % 60;
+      $h=floor($duration / 3600);
+      return $h.":".substr("0".$m,-2);
+  }
 
   /**
    * Format a number as a money value.
@@ -173,7 +185,7 @@ class BasePDF extends TCPDF {
             $this->Cell($w[1], 6, $this->timespan($row['time']), 'LR', 0, 'R', $fill); 
       } else {   
          if (isset($this->columns['time']))
-            $this->Cell($w[1], 6, gmdate('H:i',$row['std_time']), 'LR', 0, 'R', $fill);
+            $this->Cell($w[1], 6, $this->timeLength($row['std_time']), 'LR', 0, 'R', $fill);
       }   
       if (isset($this->columns['wage']))
         $this->Cell($w[2], 6, $this->money($row['wage']), 'LR', 0, 'R', $fill); 
@@ -194,7 +206,7 @@ class BasePDF extends TCPDF {
           $this->Cell($w[1], 6, $this->timespan($sum_time), '', 0, 'R', true);
     } else {   
        if (isset($this->columns['time']))
-          $this->Cell($w[1], 6, gmdate('H:i',$sum_std_time), '', 0, 'R', true);
+          $this->Cell($w[1], 6, $this->timeLength($sum_std_time), '', 0, 'R', true);
     }   
     if (isset($this->columns['wage']))
       $this->Cell($w[2], 6, $this->money($sum), 'L', 0, 'R', true); 

--- a/core/extensions/ki_export/base_export_pdf.php
+++ b/core/extensions/ki_export/base_export_pdf.php
@@ -83,7 +83,7 @@ class BasePDF extends TCPDF {
   /**
    * calculate time in hh:mm from duration lenght in second
    * rounded to minutes
-   * @param lenght in second $duration
+   * @param int $duration, duration lenght in second
    * @return string time in format hh:mm
    */
   public function timeLength($duration)

--- a/core/extensions/ki_export/base_export_pdf.php
+++ b/core/extensions/ki_export/base_export_pdf.php
@@ -82,11 +82,13 @@ class BasePDF extends TCPDF {
   
   /**
    * calculate time in hh:mm from duration lenght in second
+   * rounded to minutes
    * @param lenght in second $duration
    * @return string time in format hh:mm
    */
   public function timeLength($duration)
   {
+      $s=$duration % 60;
       $m=(($duration-$s) / 60) % 60;
       $h=floor($duration / 3600);
       return $h.":".substr("0".$m,-2);


### PR DESCRIPTION
Sorry but I was using gmdate to calculate the duration in hh:mm but gmdate cannot go over 24h so I change it for a new function timelenght which work ok for any duration lenght
