### PR TITLE
rate calculation for remote API

### DIFF
--- a/core/includes/classes/remote.class.php
+++ b/core/includes/classes/remote.class.php
@@ -676,6 +676,9 @@ class Kimai_Remote_Api
 		if(isset($record['rate'])) {
 			$data['rate'] = (double)$record['rate'];
 		}
+		else {
+			$data['rate'] = $backend->get_best_fitting_rate($data['userID'], $data['projectID'],$data['activityID']);
+		}
 		if(isset($record['fixedRate'])) {
 			$data['fixedRate'] = (double)$record['fixedRate'];
 		}


### PR DESCRIPTION
Entries added via the JSON API do not have the rate set based on user / project / activity. This small change fixes this issue.
