### PR TITLE
Upgrade PHP

### DIFF
--- a/core/installer/installscript.js
+++ b/core/installer/installscript.js
@@ -108,17 +108,15 @@ function check_system_requirements() {
     );
 }
 
-
-
 function resetRequirementsIndicators() {
     $('div.sp_phpversion').removeClass("fail");
-    $('div.sp_magicquotes').removeClass("fail");
     $('div.sp_mysql').removeClass("fail");
+    $('div.sp_iconv').removeClass("fail");
     $('div.sp_memory').removeClass("fail");
     
     $('div.sp_phpversion').addClass("ok");
-    $('div.sp_magicquotes').addClass("ok");
     $('div.sp_mysql').addClass("ok");
+    $('div.sp_iconv').addClass("ok");
     $('div.sp_memory').addClass("ok");
 }
 

--- a/core/installer/processor.php
+++ b/core/installer/processor.php
@@ -97,6 +97,11 @@ switch ($axAction) {
            $javascript .= "$('div.sp_mysql').addClass('fail');";
        }
 
+        if (!extension_loaded('iconv')) {
+            $errors++;
+            $javascript .= "$('div.sp_iconv').addClass('fail');";
+        }
+
         // magic quotes was removed in 5.4.0 - so we only check it in lower versions
         if (version_compare(PHP_VERSION, '5.4.0') < 0) {
             if (get_magic_quotes_gpc() == 1 || get_magic_quotes_runtime() == 1) {

--- a/core/installer/processor.php
+++ b/core/installer/processor.php
@@ -82,12 +82,13 @@ switch ($axAction) {
 
     /**
      * Check for the requirements of Kimai:
-     *  - PHP major version >= 5
-     *  - MySQL extension available
+     *  - PHP major version >= 5.4
+     *  - MySQLi extension available
+     *  - iconv extension available
      *  - memory limit should be at least 20 MB for reliable PDF export
      */
     case "checkRequirements":
-       if (version_compare(PHP_VERSION, '5.3') < 0) {
+       if (version_compare(PHP_VERSION, '5.4') < 0) {
            $errors++;
            $javascript .= "$('div.sp_phpversion').addClass('fail');";
        }
@@ -101,14 +102,6 @@ switch ($axAction) {
             $errors++;
             $javascript .= "$('div.sp_iconv').addClass('fail');";
         }
-
-        // magic quotes was removed in 5.4.0 - so we only check it in lower versions
-        if (version_compare(PHP_VERSION, '5.4.0') < 0) {
-            if (get_magic_quotes_gpc() == 1 || get_magic_quotes_runtime() == 1) {
-                $errors++;
-                $javascript .= "$('div.sp_magicquotes').addClass('fail');";
-            }
-       }
 
        if (return_bytes(ini_get('memory_limit')) < 20000000) {
            $javascript .= "$('div.sp_memory').addClass('fail');";

--- a/core/installer/steps/25_system_requirements.php
+++ b/core/installer/steps/25_system_requirements.php
@@ -12,7 +12,8 @@ if ($_REQUEST['lang'] == "en") {
         <div class="sp_magicquotes">Magic Quotes must be disabled.</div>
         <div class="note gray">The PHP settings magic_quotes_gpc and magic_quotes_runtime must be set to off.</div>
     <?php } ?>
-    <div class="sp_mysql">The <b>MySQL</b> extension for PHP has to be loaded.</div>
+    <div class="sp_mysql">The <b>MySQLi</b> extension for PHP has to be loaded.</div>
+    <div class="sp_iconv">The <b>iconv</b> extension for PHP has to be loaded.</div>
     <br/><br/>
     For PDF export the following requirement must be met:<br/>
     <div class="sp_memory">Allowed memory usage should be at least 20MB.</div>
@@ -30,7 +31,8 @@ if ($_REQUEST['lang'] == "en") {
         <div class="sp_magicquotes">Magic Quotes müssen deaktiviert sein.</div>
         <div class="note gray">Die PHP Einstellungen magic_quotes_gpc und magic_quotes_runtime müssen auf off gestellt sein.</div>
     <?php } ?>
-    <div class="sp_mysql">Die <b>MySQL</b> Erweiterung f&uuml;r PHP muss aktiviert sein.</div>
+    <div class="sp_mysql">Die <b>MySQLi</b> Erweiterung f&uuml;r PHP muss aktiviert sein.</div>
+    <div class="sp_iconv">Die <b>iconv</b> Erweiterung f&uuml;r PHP muss aktiviert sein.</div>
     <br/><br/>
     Damit der PDF Export zuverl&auml;ssig funktioniert m&uuml;ssen folgende Punkte erf&uuml;llt sein:<br/>
     <div class="sp_memory">Das Skript muss mind. 20MB an Speicher nutzen k&ouml;nnen.</div>

--- a/core/installer/steps/25_system_requirements.php
+++ b/core/installer/steps/25_system_requirements.php
@@ -1,23 +1,17 @@
 <script type="text/javascript" charset="utf-8">current = 25;</script>
 
 <?php
-// magic quotes "feature" was removed in 5.4.0
-$checkMagicQuotes = (version_compare(PHP_VERSION, '5.4.0') < 0);
 if ($_REQUEST['lang'] == "en") {
     ?>
     <h2>System Requirements</h2>
     The following conditions must be met:<br/>
-    <div class="sp_phpversion fail">at least PHP Major version 5.3</div>
-    <?php if ($checkMagicQuotes) { ?>
-        <div class="sp_magicquotes">Magic Quotes must be disabled.</div>
-        <div class="note gray">The PHP settings magic_quotes_gpc and magic_quotes_runtime must be set to off.</div>
-    <?php } ?>
-    <div class="sp_mysql">The <b>MySQLi</b> extension for PHP has to be loaded.</div>
-    <div class="sp_iconv">The <b>iconv</b> extension for PHP has to be loaded.</div>
+    <div class="sp_phpversion fail">at least PHP version 5.4</div>
+    <div class="sp_mysql">The <b>MySQLi</b> extension for PHP has to be loaded</div>
+    <div class="sp_iconv">The <b>iconv</b> extension for PHP has to be loaded</div>
     <br/><br/>
     For PDF export the following requirement must be met:<br/>
-    <div class="sp_memory">Allowed memory usage should be at least 20MB.</div>
-    <div class="note gray">See memory_limit in php.ini file.</div>
+    <div class="sp_memory">Allowed memory usage should be at least 20MB</div>
+    <div class="note gray">See memory_limit in php.ini file</div>
     <br/><br/>
     <button class="sp-button" onclick='check_system_requirements();'>Check requirements now</button>
     <button onclick="system_requirements_proceed(); return false;" class="invisible proceed">Proceed</button>
@@ -26,17 +20,13 @@ if ($_REQUEST['lang'] == "en") {
     ?>
     <h2>Systemanforderungen</h2>
     Die folgenden Punkte m&uuml;ssen erf&uuml;llt sein:<br/>
-    <div class="sp_phpversion fail">mindestens PHP Hauptversion 5.3</div>
-    <?php if ($checkMagicQuotes) { ?>
-        <div class="sp_magicquotes">Magic Quotes müssen deaktiviert sein.</div>
-        <div class="note gray">Die PHP Einstellungen magic_quotes_gpc und magic_quotes_runtime müssen auf off gestellt sein.</div>
-    <?php } ?>
-    <div class="sp_mysql">Die <b>MySQLi</b> Erweiterung f&uuml;r PHP muss aktiviert sein.</div>
-    <div class="sp_iconv">Die <b>iconv</b> Erweiterung f&uuml;r PHP muss aktiviert sein.</div>
+    <div class="sp_phpversion fail">mindestens PHP Version 5.4</div>
+    <div class="sp_mysql">Die <b>MySQLi</b> Erweiterung f&uuml;r PHP muss aktiviert sein</div>
+    <div class="sp_iconv">Die <b>iconv</b> Erweiterung f&uuml;r PHP muss aktiviert sein</div>
     <br/><br/>
     Damit der PDF Export zuverl&auml;ssig funktioniert m&uuml;ssen folgende Punkte erf&uuml;llt sein:<br/>
-    <div class="sp_memory">Das Skript muss mind. 20MB an Speicher nutzen k&ouml;nnen.</div>
-    <div class="note gray">Siehe memory_limit in der php.ini Datei.</div>
+    <div class="sp_memory">Das Skript muss mind. 20MB an Speicher nutzen k&ouml;nnen</div>
+    <div class="note gray">Siehe memory_limit in der php.ini Datei</div>
     <br/><br/>
     <button class="sp-button" onclick='check_system_requirements();'>Anforderungen jetzt pr&uuml;fen</button>
     <button onclick="system_requirements_proceed(); return false;" class="invisible proceed">Fortfahren</button>

--- a/core/libraries/mysql.class.php
+++ b/core/libraries/mysql.class.php
@@ -1588,9 +1588,6 @@ class MySQL
 				if (strlen($value) == 0) {
 					$return_value = "NULL";
 				} else {
-					if (get_magic_quotes_gpc()) {
-						$value = stripslashes($value);
-					}
 					$return_value = "'" . str_replace("'", "''", $value) . "'";
 				}
 				break;

--- a/core/updater.php
+++ b/core/updater.php
@@ -50,7 +50,7 @@ $revisionDB = $version_temp[1];
 error_log(serialize($version_temp));
 unset($version_temp);
 
-$min_php_version = '5.3';
+$min_php_version = '5.4';
 
 if (version_compare(PHP_VERSION, $min_php_version) < 0) {
     ?>


### PR DESCRIPTION
For future developments and the release of PHP 7 it is finally time to bump the required PHP version at least up to 5.4, which will allow us to use all the "new" PHP features.

I removed some checks for magic quotes in the same commit, as this feature was removed with PHP 5.4
