### PR TITLE
Installer - fix empty timezone list

### DIFF
--- a/installer/steps/28_timezone.php
+++ b/installer/steps/28_timezone.php
@@ -1,7 +1,41 @@
 <script type="text/javascript" charset="utf-8">current = 28;</script>
-
-
 <?php
+require "../../includes/func.php";
+
+function getTimezoneInputField()
+{
+    $html = '';
+    $serverZone = '';
+    try {
+        $serverZone = @date_default_timezone_get();
+        if (empty($serverZone)) {
+            $serverZone ='UTC';
+        }
+
+        $allZones = timezoneList();
+
+        if (!empty($allZones)) {
+            foreach ($allZones as $name) {
+                if ($name == $serverZone) {
+                    $html .= "<option selected=\"selected\">$name</option>";
+                } else {
+                    $html .= "<option>$name</option>";
+                }
+            }
+        }
+    } catch (Exception $ex) {
+        $html = '';
+    }
+
+    if (!empty($html)) {
+        return '<select id="timezone">' . $html . '</select>';
+    }
+
+    // sometimes fetching the list of timezones seems to fail
+    // see https://github.com/kimai/kimai/issues/579
+    return '<input type="text" value="'.$serverZone.'" id="timezone">';
+}
+
 if ($_REQUEST['lang'] == "en") {
     ?>
     <h2>Timezone</h2>
@@ -9,20 +43,7 @@ if ($_REQUEST['lang'] == "en") {
     Users can change their timezone through their preferences, customers can't. This setting can be changed using the
     <i>Admin Panel</i>.
     <br/><br/>
-    <select id="timezone">>
-        <?php
-        require("../../includes/func.php");
-
-        $serverZone = @date_default_timezone_get();
-
-        foreach (timezoneList() as $name) {
-            if ($name == $serverZone)
-                echo "<option selected=\"selected\">$name</option>";
-            else
-                echo "<option>$name</option>";
-        }
-        ?>
-    </select>
+    <?php echo getTimezoneInputField(); ?>
     <br/><br/>
     <button onclick="step_back(); return false;">Back</button>
     <button onclick="timezone_proceed(); return false;" class="proceed">Proceed</button>
@@ -34,20 +55,7 @@ if ($_REQUEST['lang'] == "en") {
     Benutzer können später ihre eigene Zeitzone auswählen, Kunden jedoch nicht. Die Einstellung kann später im <i>Admin
         Panel</i> geändert werden.
     <br/><br/>
-    <select id="timezone">
-        <?php
-        require("../../includes/func.php");
-
-        $serverZone = @date_default_timezone_get();
-
-        foreach (timezoneList() as $name) {
-            if ($name == $serverZone)
-                echo "<option selected=\"selected\">$name</option>";
-            else
-                echo "<option>$name</option>";
-        }
-        ?>
-    </select>
+    <?php echo getTimezoneInputField(); ?>
     <br/><br/>
     <button onclick="step_back(); return false;">Zurück</button>
     <button onclick="timezone_proceed(); return false;" class="proceed">Fortfahren</button>

--- a/installer/steps/28_timezone.php
+++ b/installer/steps/28_timezone.php
@@ -9,7 +9,7 @@ function getTimezoneInputField()
     try {
         $serverZone = @date_default_timezone_get();
         if (empty($serverZone)) {
-            $serverZone ='UTC';
+            $serverZone = 'UTC';
         }
 
         $allZones = timezoneList();
@@ -17,9 +17,9 @@ function getTimezoneInputField()
         if (!empty($allZones)) {
             foreach ($allZones as $name) {
                 if ($name == $serverZone) {
-                    $html .= "<option selected=\"selected\">$name</option>";
+                    $html .= '<option selected="selected">' . $name . '</option>';
                 } else {
-                    $html .= "<option>$name</option>";
+                    $html .= '<option>'.$name.'</option>';
                 }
             }
         }
@@ -33,7 +33,7 @@ function getTimezoneInputField()
 
     // sometimes fetching the list of timezones seems to fail
     // see https://github.com/kimai/kimai/issues/579
-    return '<input type="text" value="'.$serverZone.'" id="timezone">';
+    return '<input type="text" value="' . $serverZone . '" id="timezone">';
 }
 
 if ($_REQUEST['lang'] == "en") {


### PR DESCRIPTION
This PR adds a fallback in the installer, if the timezone list is empty.
It will replace the dropdown with an input field and also sets UTC as fallback value if the current server timezone cannot be detected.
