### PR TITLE
Fix open_basedir problems

### DIFF
--- a/includes/basics.php
+++ b/includes/basics.php
@@ -26,6 +26,15 @@
 defined('WEBROOT') || define('WEBROOT', dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR);
 defined('APPLICATION_PATH') || define('APPLICATION_PATH', realpath(dirname(__FILE__) . '/../'));
 
+set_include_path(
+    implode(
+        PATH_SEPARATOR,
+        array(
+            realpath(APPLICATION_PATH . '/libraries/zendframework/zendframework1/library/'),
+        )
+    )
+);
+
 if (!file_exists(WEBROOT . 'includes/autoconf.php')) {
     header('Location: installer/index.php');
     exit;


### PR DESCRIPTION
In environments utilizing the open_basedir setting from PHP, there occured error logs, because ZF1 tried to open files within the complete include_path - which might have path settings set that were outside the open_basedir limitations.
It does not affect Kimai itself, but it spams the logfiles.

This code was previously available, but was accidentaly deleted with the autoloading feature of composer, so this is only a revert commit.
