### PR TITLE
Travis-Hotfix for hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ php:
   - 5.6
   - 7.0
   - hhvm
-  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: 7.0
     - php: hhvm
-    - php: hhvm-nightly
 
 before_script:
   - ./.travis.install.sh


### PR DESCRIPTION
hhvm-nightly is not supported on travis any longer
See https://github.com/facebook/hhvm/issues/5220 and https://travis-ci.org/kimai/kimai/jobs/113526929
