### PR TITLE
Remove preferences link for customers

### DIFF
--- a/templates/scripts/core/main.php
+++ b/templates/scripts/core/main.php
@@ -195,8 +195,10 @@
         
         <div id="main_tools_menu">
             <div class="slider">
-                <a href="#" id="main_credits_button"><?php echo $this->kga['lang']['about'] ?></a> |
-                <a href="#" id="main_prefs_button"><?php echo $this->kga['lang']['preferences'] ?></a>
+                <a href="#" id="main_credits_button"><?php echo $this->kga['lang']['about'] ?></a>
+                <?php if (!isset($this->kga['customer'])) { ?>
+                 | <a href="#" id="main_prefs_button"><?php echo $this->kga['lang']['preferences'] ?></a>
+                <?php } ?>
             </div>
             <div class="end"></div>
         </div>


### PR DESCRIPTION
Remove the link to preferences for customers (which is not available for them).

See https://github.com/kimai/kimai/blob/master/core/floaters.php#L59 and following, why the link should not be there.

Fixes #596
