### PR TITLE
Hotfix for #557 - cannot create time entry without rate

### DIFF
--- a/extensions/ki_timesheets/processor.php
+++ b/extensions/ki_timesheets/processor.php
@@ -557,7 +557,10 @@ switch ($axAction) {
           }
 
           Kimai_Logger::logfile("timeEntry_create");
-          $database->timeEntry_create($data);
+          $createdId = $database->timeEntry_create($data);
+          if (!$createdId) {
+            $errors[''] = $kga['lang']['error'];
+          }
         }
 
         $database->transaction_end();

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -2173,7 +2173,7 @@ class Kimai_Database_Mysql
         $values['start']        = MySQL::SQLValue($data['start'], MySQL::SQLVALUE_NUMBER);
         $values['end']          = MySQL::SQLValue($data['end'], MySQL::SQLVALUE_NUMBER);
         $values['duration']     = MySQL::SQLValue($data['duration'], MySQL::SQLVALUE_NUMBER);
-        $values['rate']         = MySQL::SQLValue($data['rate'], MySQL::SQLVALUE_NUMBER);
+        $values['rate']         = MySQL::SQLValue($data['rate'] ? $data['rate'] : 0, MySQL::SQLVALUE_NUMBER);
         $values['cleared']      = MySQL::SQLValue($data['cleared'] ? 1 : 0, MySQL::SQLVALUE_NUMBER);
         $values['budget']       = MySQL::SQLValue($data['budget'], MySQL::SQLVALUE_NUMBER);
         $values['approved']     = MySQL::SQLValue($data['approved'], MySQL::SQLVALUE_NUMBER);
@@ -4189,8 +4189,11 @@ class Kimai_Database_Mysql
             return false;
         }
 
-        if ($this->conn->RowCount() == 0)
-            return false;
+        if ($this->conn->RowCount() == 0) {
+            // no error, but no best fitting rate, return default value
+            Kimai_Logger::logfile("get_best_fitting_rate - using default rate 0.00");
+            return 0.00;
+        }
 
         $data = $this->conn->rowArray(0, MYSQLI_ASSOC);
         return $data['rate'];


### PR DESCRIPTION
This is a bugfix for #557 

It incorporates changes inspired by @cljk https://github.com/cljk/kimai/commit/43c3c936c7175c19747ed88b852f305df66f5ed8
- return 0.00 as best fitting rate if none could be found in the database
- display an error if a new timesheet entry could not be created (currently the floater closes silently) and keep the floater visible
- set the rate to 0.00 in Mysql class if not present, as safety caution
