### PR TITLE
Permission bugfixes

### DIFF
--- a/core/processor.php
+++ b/core/processor.php
@@ -161,15 +161,15 @@ switch ($axAction) {
     break;
 
     /**
-     * Return a list of users. Customers are not shown any users. The
-     * type of the current user decides which users are shown to him.
-     * See get_user_watchable_users.
+     * Return a list of users.
+     * The type of the current user decides which users are shown to him.
+     * @see kimai.php as well
      */
     case 'reload_users':
         if (isset($kga['customer'])) {
-                    $view->users = array();
+            $view->users = $database->get_customer_watchable_users($kga['customer']);
         } else {
-                    $view->users = $database->get_user_watchable_users($kga['user']);
+            $view->users = $database->get_user_watchable_users($kga['user']);
         }
 
         echo $view->render("lists/users.php");

--- a/includes/func.php
+++ b/includes/func.php
@@ -161,7 +161,7 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
             break;
 
         case 'allUser':
-            $users = $database->get_users($kga['user']);
+            $users = $database->get_users();
 
             foreach ($users as $user) {
               if ($includeDeleted || !$user['trash']) {

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -3728,6 +3728,12 @@ class Kimai_Database_Mysql
             return $that->membership_role_allows($roleID, 'core-user-view');
         });
 
+        // user is not allowed to see users of different groups, so he only gets to see himself
+        if(empty($allowed_groups)) {
+            return array($user);
+        }
+
+        // otherwise return the list of all active users within the allowed groups
         return $this->get_users(0, $allowed_groups);
     }
 


### PR DESCRIPTION
There were some "hidden" problems in Kimai, when working with none admin users:
- a user without the "role membership permission" > "regular user" > "view" could see all users in the system (thanks @Nef10) 
- customers got to see no users after refreshing the sublist "users", which was initially filled correctly
- when populating the select box for "allUser" a wrong parameter was passed (due to PHPs forgiving nature, it did not lead to a bug here)
