### PR TITLE
add missing "event" parameter to resetPassword click callback

### DIFF
--- a/templates/scripts/login/panel.php
+++ b/templates/scripts/login/panel.php
@@ -30,7 +30,7 @@
           return false;
         });
 
-        $("#resetPassword").click(function() {
+        $("#resetPassword").click(function(event) {
           event.preventDefault();
           $("#forgotPasswordUsername").blur();
           $.ajax({


### PR DESCRIPTION
Changes proposed in this pull request:
- added missing "event" parameter to resetPassword click callback

Reasons for this pull request:
- without the "event" parameter in the callback, the callback does not work in Firefox

@kimai/core-team
