### PR TITLE
add missing "event" parameter to loginButton click callback

### DIFF
--- a/templates/scripts/login/forgotPassword.php
+++ b/templates/scripts/login/forgotPassword.php
@@ -31,7 +31,7 @@
           return false;
         });
 
-        $("#loginButton").click(function() {
+        $("#loginButton").click(function(event) {
           requestData['password'] = $("#password").val();
           event.preventDefault();
           $.ajax({


### PR DESCRIPTION
Changes proposed in this pull request:
- added missing "event" parameter to loginButton click callback

Reasons for this pull request:
- callback does not work in Firefox without the "event" parameter

@kimai/core-team
