### PR TITLE
Fixes multiple Undefined offset

### DIFF
--- a/extensions/ki_expenses/private_db_layer_mysql.php
+++ b/extensions/ki_expenses/private_db_layer_mysql.php
@@ -65,70 +65,22 @@ function expense_create($userID, $data) {
     }
 
     return $result;
-} 
-
-
-
-/**
- *  Creates an array of clauses which can be joined together in the WHERE part
- *  of a sql query. The clauses describe whether a line should be included
- *  depending on the filters set.
- *  
- *  This method also makes the values SQL-secure.
- *
- * @param Array list of IDs of users to include
- * @param Array list of IDs of customers to include
- * @param Array list of IDs of projects to include
- * @param Array list of IDs of activities to include
- * @return Array list of where clauses to include in the query
- *
- */
-
-function expenses_widthhereClausesFromFilters($users, $customers, $projects) {
-    
-    if (!is_array($users)) $users = array();
-    if (!is_array($customers)) $customers = array();
-    if (!is_array($projects)) $projects = array();
-
-    for ($i = 0; $i < count($users); $i++)
-      $users[$i] = MySQL::SQLValue($users[$i], MySQL::SQLVALUE_NUMBER);
-    for ($i = 0; $i < count($customers); $i++)
-      $customers[$i] = MySQL::SQLValue($customers[$i], MySQL::SQLVALUE_NUMBER);
-    for ($i = 0; $i < count($projects); $i++)
-      $projects[$i] = MySQL::SQLValue($projects[$i], MySQL::SQLVALUE_NUMBER);
-
-    $whereClauses = array();
-    
-    if (count($users) > 0) {
-      $whereClauses[] = "userID in (" . implode(',', $users) . ")";
-    }
-    
-    if (count($customers) > 0) {
-      $whereClauses[] = "customerID in (" . implode(',', $customers) . ")";
-    }
-    
-    if (count($projects) > 0) {
-      $whereClauses[] = "projectID in (" . implode(',', $projects) . ")";
-    }  
-
-    return $whereClauses;
-
 }
 
 /**
  * returns expenses for specific user as multidimensional array
+ * TODO: Test it!
  *
- * @param integer $user ID of user in table users
- * @global array $kga kimai-global-array
+ * @param $start
+ * @param $end
+ * @param null $users
+ * @param null $customers
+ * @param null $projects
+ * @param bool $limit
+ * @param bool $reverse_order
+ * @param int $filter_refundable
+ * @param null $filterCleared
  * @return array
- * @author th 
- */
-
-// TODO: Test it!
-/**
- * @param integer $start
- * @param integer $end
- * @param integer $filterCleared
  */
 function get_expenses($start, $end, $users = null, $customers = null, $projects = null, $limit = false, $reverse_order = false, $filter_refundable = -1, $filterCleared = null) {
     global $kga, $database;
@@ -143,9 +95,9 @@ function get_expenses($start, $end, $users = null, $customers = null, $projects 
     $end = MySQL::SQLValue($end, MySQL::SQLVALUE_NUMBER);
     $limit = MySQL::SQLValue($limit, MySQL::SQLVALUE_NUMBER);
 
-    $p     = $kga['server_prefix'];
+    $p = $database->getTablePrefix();
 
-    $whereClauses = expenses_widthhereClausesFromFilters($users, $customers, $projects);
+    $whereClauses = $database->timeSheet_whereClausesFromFilters($users, $customers, $projects);
 
     if (isset($kga['customer']))
       $whereClauses[] = "project.internal = 0";
@@ -338,8 +290,8 @@ function expenses_by_user($start, $end, $users = null, $customers = null, $proje
     $start = MySQL::SQLValue($start, MySQL::SQLVALUE_NUMBER);
     $end   = MySQL::SQLValue($end, MySQL::SQLVALUE_NUMBER);
 
-    $p     = $kga['server_prefix'];
-    $whereClauses = expenses_widthhereClausesFromFilters($users, $customers, $projects);
+    $p = $database->getTablePrefix();
+    $whereClauses = $database->timeSheet_whereClausesFromFilters($users, $customers, $projects);
     $whereClauses[] = "${p}users.trash = 0";
 
     if ($start)
@@ -385,9 +337,9 @@ function expenses_by_customer($start, $end, $users = null, $customers = null, $p
     $start = MySQL::SQLValue($start, MySQL::SQLVALUE_NUMBER);
     $end   = MySQL::SQLValue($end, MySQL::SQLVALUE_NUMBER);
 
-    $p     = $kga['server_prefix'];
-
-    $whereClauses = expenses_widthhereClausesFromFilters($users, $customers, $projects);
+    $p = $database->getTablePrefix();
+    
+    $whereClauses = $database->timeSheet_whereClausesFromFilters($users, $customers, $projects);
     $whereClauses[] = "${p}customers.trash = 0";
 
     if ($start)
@@ -429,8 +381,8 @@ function expenses_by_project($start, $end, $users = null, $customers = null, $pr
     $start = MySQL::SQLValue($start, MySQL::SQLVALUE_NUMBER);
     $end   = MySQL::SQLValue($end, MySQL::SQLVALUE_NUMBER);
 
-    $p     = $kga['server_prefix'];
-    $whereClauses = expenses_widthhereClausesFromFilters($users, $customers, $projects);
+    $p = $database->getTablePrefix();
+    $whereClauses = $database->timeSheet_whereClausesFromFilters($users, $customers, $projects);
     $whereClauses[] = "${p}projects.trash = 0";
 
     if ($start)

--- a/extensions/ki_export/templates/scripts/main.php
+++ b/extensions/ki_export/templates/scripts/main.php
@@ -27,7 +27,7 @@
                 <a onclick="export_toggle_column('budget');" title="<?php echo $this->kga['lang']['budget'] ?>"><?php echo $this->ellipsis($this->kga['lang']['budget'], 5) ?></a>
             </td>
             <td class="approved <?php if (isset($this->disabled_columns['approved'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('approved');" title="<?php echo $this->kga['lang']['approved'] ?>"><?php echo $this->ellipsis($this->kga['lang']['approved'], 5) ?></a>
+                <a onclick="export_toggle_column('approved');" title="<?php echo $this->kga['lang']['approved'] ?>"><?php echo $this->ellipsis($this->kga['lang']['approved'], 4) ?></a>
             </td>
             <td class="status <?php if (isset($this->disabled_columns['status'])): ?>disabled<?php endif; ?>">
                 <a onclick="export_toggle_column('status');" title="<?php echo $this->kga['lang']['status'] ?>"><?php echo $this->ellipsis($this->kga['lang']['status'], 4) ?></a>

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -128,6 +128,14 @@ class Kimai_Database_Mysql
     }
 
     /**
+     * @return string
+     */
+    public function getTablePrefix()
+    {
+        return $this->kga['server_prefix'];
+    }
+
+    /**
      * @return string tablename including prefix
      */
     public function getProjectTable()
@@ -2484,20 +2492,19 @@ class Kimai_Database_Mysql
     }
 
     /**
-     *  Creates an array of clauses which can be joined together in the WHERE part
-     *  of a sql query. The clauses describe whether a line should be included
-     *  depending on the filters set.
+     * Creates an array of clauses which can be joined together in the WHERE part
+     * of a sql query. The clauses describe whether a line should be included
+     * depending on the filters set.
      *
-     *  This method also makes the values SQL-secure.
+     * This method also makes the values SQL-secure.
      *
      * @param array $users list of IDs of users to include
      * @param array $customers list of IDs of customers to include
      * @param array $projects list of IDs of projects to include
      * @param array $activities list of IDs of activities to include
      * @return array list of where clauses to include in the query
-     *
      */
-    public function timeSheet_whereClausesFromFilters($users, $customers, $projects, $activities)
+    public function timeSheet_whereClausesFromFilters($users, $customers, $projects, $activities = array())
     {
         if (!is_array($users)) {
             $users = array();
@@ -2512,17 +2519,17 @@ class Kimai_Database_Mysql
             $activities = array();
         }
 
-        for ($i = 0; $i < count($users); $i++) {
-            $users[$i] = MySQL::SQLValue($users[$i], MySQL::SQLVALUE_NUMBER);
+        foreach ($users as $i => $value) {
+            $users[$i] = MySQL::SQLValue($value, MySQL::SQLVALUE_NUMBER);
         }
-        for ($i = 0; $i < count($customers); $i++) {
-            $customers[$i] = MySQL::SQLValue($customers[$i], MySQL::SQLVALUE_NUMBER);
+        foreach ($customers as $i => $value) {
+            $customers[$i] = MySQL::SQLValue($value, MySQL::SQLVALUE_NUMBER);
         }
-        for ($i = 0; $i < count($projects); $i++) {
-            $projects[$i] = MySQL::SQLValue($projects[$i], MySQL::SQLVALUE_NUMBER);
+        foreach ($projects as $i => $value) {
+            $projects[$i] = MySQL::SQLValue($value, MySQL::SQLVALUE_NUMBER);
         }
-        for ($i = 0; $i < count($activities); $i++) {
-            $activities[$i] = MySQL::SQLValue($activities[$i], MySQL::SQLVALUE_NUMBER);
+        foreach ($activities as $i => $value) {
+            $activities[$i] = MySQL::SQLValue($value, MySQL::SQLVALUE_NUMBER);
         }
 
         $whereClauses = array();
@@ -3918,12 +3925,15 @@ class Kimai_Database_Mysql
                 $consideredEnd = $end;
             }
 
+            $time = (int)($consideredEnd - $consideredStart);
+            $costs = (double)$row['costs'];
+
             if (isset($arr[$row['userID']])) {
-                $arr[$row['userID']]['time']  += (int)($consideredEnd - $consideredStart);
-                $arr[$row['userID']]['costs'] += (double)$row['costs'];
+                $arr[$row['userID']]['time']  += $time;
+                $arr[$row['userID']]['costs'] += $costs;
             } else {
-                $arr[$row['userID']]['time'] = (int)($consideredEnd - $consideredStart);
-                $arr[$row['userID']]['costs'] = (double)$row['costs'];
+                $arr[$row['userID']]['time'] = $time;
+                $arr[$row['userID']]['costs'] = $costs;
             }
         }
 

--- a/libraries/Kimai/Remote/Database.php
+++ b/libraries/Kimai/Remote/Database.php
@@ -27,21 +27,33 @@
  */
 class Kimai_Remote_Database
 {
+    /**
+     * @var array|null
+     */
     private $kga = null;
+    /**
+     * @var string
+     */
     private $tablePrefix = null;
+    /**
+     * @var Kimai_Database_Mysql
+     */
     private $dbLayer = null;
+    /**
+     * @var MySQL
+     */
     private $conn = null;
 
     /**
      * Kimai_Remote_Database constructor.
-     * @param $kga
-     * @param $database
+     * @param array $kga
+     * @param Kimai_Database_Mysql $database
      */
     public function __construct($kga, $database)
     {
         $oldDatabase = $database;
 
-        $this->tablePrefix = $kga['server_prefix'];
+        $this->tablePrefix = $database->getTablePrefix();
         $this->kga = $kga;
         $this->dbLayer = $oldDatabase;
         $this->conn = $this->dbLayer->getConnectionHandler();
@@ -136,7 +148,7 @@ class Kimai_Remote_Database
 
         $p = $kga['server_prefix'];
 
-        $whereClauses = $this->expenses_widthhereClausesFromFilters($users, $customers, $projects);
+        $whereClauses = $this->dbLayer->timeSheet_whereClausesFromFilters($users, $customers, $projects);
 
         if (isset($kga['customer'])) {
             $whereClauses[] = "${p}projects.internal = 0";
@@ -215,64 +227,10 @@ class Kimai_Remote_Database
     }
 
     /**
-     *  Creates an array of clauses which can be joined together in the WHERE part
-     *  of a sql query. The clauses describe whether a line should be included
-     *  depending on the filters set.
-     *
-     *  This method also makes the values SQL-secure.
-     *
-     * @param array list of IDs of users to include
-     * @param array list of IDs of customers to include
-     * @param array list of IDs of projects to include
-     * @param array list of IDs of activities to include
-     * @param integer|null $users
-     * @return array list of where clauses to include in the query
-     */
-    public function expenses_widthhereClausesFromFilters($users, $customers, $projects)
-    {
-        if (!is_array($users)) {
-            $users = array();
-        }
-        if (!is_array($customers)) {
-            $customers = array();
-        }
-        if (!is_array($projects)) {
-            $projects = array();
-        }
-
-        for ($i = 0; $i < count($users); $i++) {
-            $users[$i] = MySQL::SQLValue($users[$i], MySQL::SQLVALUE_NUMBER);
-        }
-        for ($i = 0; $i < count($customers); $i++) {
-            $customers[$i] = MySQL::SQLValue($customers[$i], MySQL::SQLVALUE_NUMBER);
-        }
-        for ($i = 0; $i < count($projects); $i++) {
-            $projects[$i] = MySQL::SQLValue($projects[$i], MySQL::SQLVALUE_NUMBER);
-        }
-
-        $whereClauses = array();
-
-        if (count($users) > 0) {
-            $whereClauses[] = "userID in (" . implode(',', $users) . ")";
-        }
-
-        if (count($customers) > 0) {
-            $whereClauses[] = "customerID in (" . implode(',', $customers) . ")";
-        }
-
-        if (count($projects) > 0) {
-            $whereClauses[] = "projectID in (" . implode(',', $projects) . ")";
-        }
-
-        return $whereClauses;
-    }
-
-    /**
      * create exp entry
      *
      * @param array $data
-     * @author sl
-     * @author Alexander Bauer
+     * @return int
      */
     public function expense_create(array $data)
     {
@@ -319,8 +277,7 @@ class Kimai_Remote_Database
      *
      * @param integer $id
      * @param array $data
-     * @author th
-     * @author Alexander Bauer
+     * @return object
      */
     public function expense_edit($id, array $data)
     {
@@ -359,8 +316,7 @@ class Kimai_Remote_Database
      * delete exp entry
      *
      * @param integer $id -> ID of record
-     * @global array $kga kimai-global-array
-     * @author th
+     * @return object
      */
     public function expense_delete($id)
     {


### PR DESCRIPTION
Changes proposed in this pull request:
- remove function expenses_widthhereClausesFromFilters which was a duplicate of timeSheet_whereClausesFromFilters
- Fixed some phpdocs

Reason for this pull request:
1. When selecting/filtering customer 1 and 3 from the customer list, the submitted array looked like this: `array(1, 3)` and the for() loop in the helper methods tried to fetch `customer[0], customer[1], customer[2], customer[3]`which lead to multiple undefined index notices.
   This was fixed by using foreach instead
2. The function `expenses_widthhereClausesFromFilters` was a Copy&Paste of database method `timeSheet_whereClausesFromFilters`, just missing the (now optional) parameter activities. So the "undefined index" notice popped up in several places. 
   This was fixed by replacing all `expenses_widthhereClausesFromFilters` calls, so we have the logic in one place only.
3. The global config key `server_prefix` should not be utilized by extensions. 
   A first step in fixing that is the new method in database layer to return the prefix. 
