### PR TITLE
Hide all related projects if client is made invisible

### DIFF
--- a/core/floaters.php
+++ b/core/floaters.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of
  * Kimai - Open Source Time Tracking // http://www.kimai.org
- * (c) 2006-2009 Kimai-Development-Team
+ * (c) Kimai-Development-Team since 2006
  *
  * Kimai is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,8 +29,7 @@
 // insert KSPI
 $isCoreProcessor = 1;
 $dir_templates = "templates/scripts/"; // folder of the template files
-require("../includes/kspi.php");
-
+require "../includes/kspi.php";
 
 switch ($axAction) {
 
@@ -135,7 +134,7 @@ switch ($axAction) {
             foreach ($kga['user']['groups'] as $group) {
                $membershipRoleID = $database->user_get_membership_role($kga['user']['userID'], $group);
                if ($database->membership_role_allows($membershipRoleID, 'core-user-add')) {
-                                $view->selectedGroups[] = $group;
+                   $view->selectedGroups[] = $group;
                }
             }
             $view->id = 0;
@@ -150,17 +149,17 @@ switch ($axAction) {
     case 'add_edit_project':
         $oldGroups = array();
         if ($id) {
-                  $oldGroups = $database->project_get_groupIDs($id);
+            $oldGroups = $database->project_get_groupIDs($id);
         }
 
         if (!checkGroupedObjectPermission('Project', $id ? 'edit' : 'add', $oldGroups, $oldGroups)) {
             die();
         }
- 
-        $view->customers = makeSelectBox("customer", $kga['user']['groups'], isset($data) ? $data['customerID'] : null);
+
+        $view->customers = makeSelectBox("customer", $kga['user']['groups'], (isset($data) ? $data['customerID'] : null));
         $view->groups = makeSelectBox("group", $kga['user']['groups']);
         $view->allActivities = $database->get_activities($kga['user']['groups']);
-
+ 
         if ($id) {
             $data = $database->project_get_data($id);
             if ($data) {
@@ -181,13 +180,15 @@ switch ($axAction) {
                 $view->id = $id;
 
                 if (!isset($view->customers[$data['customerID']])) {
-                  // add the currently assigned customer to the list although the user is in no group to see him
-                  $customerData = $database->customer_get_data($data['customerID']);
-                  $view->customers[$data['customerID']] = $customerData['name'];
+                    // add the currently assigned customer to the list although
+                    // a) the user is in no group to see him
+                    // b) the customer is hidden
+                    $customerData = $database->customer_get_data($data['customerID']);
+                    $view->customers[$data['customerID']] = $customerData['name'];
                 }
             }
         }
-        
+
         if (!isset($view->id)) {
           $view->selectedActivities = array();
           $view->internal = false;
@@ -199,7 +200,7 @@ switch ($axAction) {
             foreach ($kga['user']['groups'] as $group) {
                $membershipRoleID = $database->user_get_membership_role($kga['user']['userID'], $group);
                if ($database->membership_role_allows($membershipRoleID, 'core-project-add')) {
-                                $view->selectedGroups[] = $group;
+                    $view->selectedGroups[] = $group;
                }
             }
 
@@ -216,12 +217,14 @@ switch ($axAction) {
     case 'add_edit_activity':
         $oldGroups = array();
         if ($id) {
-                  $oldGroups = $database->activity_get_groupIDs($id);
+          $oldGroups = $database->activity_get_groupIDs($id);
         }
 
         if (!checkGroupedObjectPermission('Activity', $id ? 'edit' : 'add', $oldGroups, $oldGroups)) {
             die();
         }
+
+        $selectedProjects = array();
 
         if ($id) {
             $data = $database->activity_get_data($id);
@@ -234,17 +237,17 @@ switch ($axAction) {
                 $view->myRate       = $data['myRate'];
                 $view->fixedRate    = $data['fixedRate'];
                 $view->selectedGroups = $database->activity_get_groups($id);
-                $view->selectedProjects = $database->activity_get_projects($id);
+                $selectedProjects = $database->activity_get_projects($id);
+                $view->selectedProjects = $selectedProjects;
                 $view->id = $id;
-        
             }
         }
 
-        // Create a <select> element to chosse the groups.
+        // Create a <select> element to choose the groups.
         $view->groups = makeSelectBox("group", $kga['user']['groups']);
 
         // Create a <select> element to chosse the projects.
-        $view->projects = makeSelectBox("project", $kga['user']['groups']);
+        $view->projects = makeSelectBox("project", $kga['user']['groups'], null, false, $selectedProjects);
 
         // Set defaults for a new project.
         if (!$id) {
@@ -252,7 +255,7 @@ switch ($axAction) {
             foreach ($kga['user']['groups'] as $group) {
                $membershipRoleID = $database->user_get_membership_role($kga['user']['userID'], $group);
                if ($database->membership_role_allows($membershipRoleID, 'core-activity-add')) {
-                                $view->selectedGroups[] = $group;
+                    $view->selectedGroups[] = $group;
                }
             }
             $view->id = 0;

--- a/extensions/ki_adminpanel/templates/scripts/projects.php
+++ b/extensions/ki_adminpanel/templates/scripts/projects.php
@@ -28,7 +28,7 @@
 	{
 		foreach ($this->projects as $row) 
 		{
-			$isHidden = $row['visible'] != 1;
+			$isHidden = $row['visible'] != 1 || $row['customerVisible'] != 1;
 			?>
 			<tr class="<?php echo $this->cycle(array("odd","even"))->next()?>">
 				<td class="option">

--- a/includes/func.php
+++ b/includes/func.php
@@ -85,7 +85,7 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
         case 'project':
             $projects = $database->get_projects($groups);
             foreach ($projects as $project) {
-                if ($project['visible']) {
+                if ($project['visible'] && $project['customerVisible']) {
                     if ($kga['conf']['flip_project_display']) {
                         $projectName = $project['customerName'] . ": " . $project['name'];
                         if ($kga['conf']['project_comment_flag']) {
@@ -119,7 +119,7 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
 	                if ($customer['visible']) {
 	                    $sel[$customer['customerID']] = $customer['name'];
 	                    if ($selection == $customer['customerID']) {
-	                    	                      $selectionFound = true;
+                            $selectionFound = true;
 	                    }
 	                }
 	            }
@@ -141,7 +141,6 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
                     }
                 );
             }
-
 
             foreach ($groups as $group) {
                 if ($includeDeleted || !$group['trash']) {

--- a/includes/func.php
+++ b/includes/func.php
@@ -63,7 +63,7 @@ function timezoneList() {
 }
 
 /**
- * Returns array for smarty's html_options funtion.
+ * Returns array for rendering a select input.
  *
  * <pre>
  * returns:
@@ -71,11 +71,14 @@ function timezoneList() {
  * [1] -> values as IDs
  * </pre>
  *
- * @param string either 'project', 'activity', 'customer', 'group'
+ * @param string $subject one of 'project', 'activity', 'customer', 'group', 'sameGroupUser', 'user'
+ * @param $groups
+ * @param null $selection
+ * @param bool $includeDeleted
+ * @param array $showIds an array of IDs that should be shown, no matter of their visibility
  * @return array
- * @author th, sl, kp
  */
-function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = false) {
+function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = false, $showIds = array()) {
 
     global $kga, $database;
 
@@ -85,7 +88,7 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
         case 'project':
             $projects = $database->get_projects($groups);
             foreach ($projects as $project) {
-                if ($project['visible'] && $project['customerVisible']) {
+                if (($project['visible'] && $project['customerVisible']) || in_array($project['projectID'], $showIds)) {
                     if ($kga['conf']['flip_project_display']) {
                         $projectName = $project['customerName'] . ": " . $project['name'];
                         if ($kga['conf']['project_comment_flag']) {
@@ -105,7 +108,7 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
         case 'activity':
             $activities = $database->get_activities($groups);
             foreach ($activities as $activity) {
-                if ($activity['visible']) {
+                if ($activity['visible'] || in_array($activity['activityID'], $showIds)) {
                     $sel[$activity['activityID']] = $activity['name'];
                 }
             }
@@ -116,7 +119,7 @@ function makeSelectBox($subject, $groups, $selection = null, $includeDeleted = f
             $selectionFound = false;
             if (is_array($customers)) {
 	            foreach ($customers as $customer) {
-	                if ($customer['visible']) {
+	                if ($customer['visible'] || in_array($customer['customerID'], $showIds)) {
 	                    $sel[$customer['customerID']] = $customer['name'];
 	                    if ($selection == $customer['customerID']) {
                             $selectionFound = true;

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -2384,9 +2384,9 @@ class Kimai_Database_Mysql
         }
 
         if ($this->kga['conf']['flip_project_display']) {
-            $query .= " ORDER BY project.visible DESC, customerName, name;";
+            $query .= " ORDER BY project.visible DESC, customer.visible DESC, customerName, name;";
         } else {
-            $query .= " ORDER BY project.visible DESC, name, customerName;";
+            $query .= " ORDER BY project.visible DESC, customer.visible DESC, name, customerName;";
         }
 
         $result = $this->conn->Query($query);
@@ -3066,7 +3066,14 @@ class Kimai_Database_Mysql
         return array();
     }
 
-    ## Load into Array: Activities
+    /**
+     * Get all available activities.
+     *
+     * This is either a list of all or a list of all for the given groups.
+     *
+     * @param array|null $groups
+     * @return array|bool
+     */
     public function get_activities(array $groups = null)
     {
         $p = $this->kga['server_prefix'];
@@ -3103,9 +3110,9 @@ class Kimai_Database_Mysql
                 $i++;
             }
             return $arr;
-        } else {
-            return array();
         }
+
+        return array();
     }
 
     /**
@@ -3166,9 +3173,8 @@ class Kimai_Database_Mysql
                 $arr[$row->activityID]['effort'] = $row->effort;
             }
             return $arr;
-        } else {
-            return array();
         }
+        return array();
     }
 
     /**

--- a/templates/helpers/FilterListEntries.php
+++ b/templates/helpers/FilterListEntries.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of
  * Kimai - Open Source Time Tracking // http://www.kimai.org
- * (c) 2006-2012 Kimai-Development-Team
+ * (c) Kimai-Development-Team since 2006
  *
  * Kimai is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,8 +19,6 @@
 
 /**
  * Filters the given list entries.
- *
- * @author Kevin Papst
  */
 class Zend_View_Helper_FilterListEntries extends Zend_View_Helper_Abstract
 {
@@ -37,12 +35,23 @@ class Zend_View_Helper_FilterListEntries extends Zend_View_Helper_Abstract
 
         $listEntries = array();
         foreach ($entries as $row) {
-            if ($filterHidden && isset($row['visible']) && !$row['visible']) {
+            if ($filterHidden &&
+                ($this->filter($row, 'visible') || $this->filter($row, 'customerVisible'))) {
                 continue;
             }
             $listEntries[] = $row;
         }
 
         return $listEntries;
+    }
+
+    /**
+     * @param $row
+     * @param $key
+     * @return bool
+     */
+    protected function filter($row, $key)
+    {
+        return isset($row[$key]) && !$row[$key];
     }
 } 

--- a/templates/scripts/lists/activities.php
+++ b/templates/scripts/lists/activities.php
@@ -39,9 +39,7 @@ $activities = $this->filterListEntries($this->activities);
                 </td>
 
                 <td width="100%" class="activities" onclick="buzzer_preselect_activity(<?php echo $activity['activityID']?>,'<?php echo $this->jsEscape($activity['name'])?>'); return false;" onmouseover="lists_change_color(this,true);" onmouseout="lists_change_color(this,false);">
-                    <?php if ($activity['visible'] != 1): ?><span style="color:#bbb"><?php endif; ?>
                     <?php if ($this->kga['conf']['showIDs'] == 1): ?><span class="ids"><?php echo $activity['activityID']?></span> <?php endif; echo $this->escape($activity['name']) ?>
-                    <?php if ($activity['visible'] != 1): ?></span><?php endif; ?>
                 </td>
 
                 <td nowrap class="annotation"></td>

--- a/templates/scripts/lists/customers.php
+++ b/templates/scripts/lists/customers.php
@@ -20,10 +20,8 @@ $customers = $this->filterListEntries($this->customers);
         foreach ($customers as  $customer)
         {
             ?>
-
             <tr id="row_customer" data-id="<?php echo $customer['customerID']?>" class="customer customer<?php echo $customer['customerID']?> <?php echo $this->cycle(array('odd','even'))->next()?>">
 
-              <!-- option cell -->
               <td nowrap class="option">
                 <?php if ($this->show_customer_edit_button): ?>
                 <a href="#" onclick="editSubject('customer',<?php echo $customer['customerID']?>); $(this).blur(); return false;">
@@ -35,14 +33,10 @@ $customers = $this->filterListEntries($this->customers);
                 </a>
               </td>
 
-              <!-- name cell -->
               <td width="100%" class="clients" onmouseover="lists_change_color(this,true);" onmouseout="lists_change_color(this,false);" onclick="lists_customer_highlight(<?php echo $customer['customerID']?>); $(this).blur(); return false;">
-                  <?php if ($customer['visible'] != 1): ?><span style="color:#bbb"><?php endif; ?>
                   <?php if ($this->kga['conf']['showIDs'] == 1): ?><span class="ids"><?php echo $customer['customerID']?></span> <?php endif; echo $this->escape($customer['name'])?>
-                  <?php if ($customer['visible'] != 1): ?></span><?php endif; ?>
               </td>
 
-              <!-- annotation cell -->
               <td nowrap class="annotation"></td>
             </tr>
             <?php

--- a/templates/scripts/lists/projects.php
+++ b/templates/scripts/lists/projects.php
@@ -37,7 +37,6 @@ $projects = $this->filterListEntries($this->projects);
             </td>
 
             <td width="100%" class="projects" onmouseover="lists_change_color(this,true);" onmouseout="lists_change_color(this,false);" onclick="buzzer_preselect_project(<?php echo $project['projectID']?>,'<?php echo $this->jsEscape($project['name'])?>',<?php echo $project['customerID']?>,'<?php echo $this->jsEscape($project['customerName'])?>'); lists_reload('activity'); return false;">
-                <?php if ($project['visible'] != 1): ?><span style="color:#bbb"><?php endif; ?>
                 <?php if ($this->kga['conf']['flip_project_display']): ?>
                     <?php if ($this->kga['conf']['showIDs'] == 1): ?>
                       <span class="ids"><?php echo $project['projectID']?></span>
@@ -64,7 +63,6 @@ $projects = $this->filterListEntries($this->projects);
                         <span class="lighter">(<?php echo $this->escape($this->truncate($project['customerName'],30,'...')) ?>)</span>
                     <?php endif; ?>
                 <?php endif; ?>
-                <?php if ($project['visible'] != 1): ?></span><?php endif; ?>
             </td>
             <td nowrap class="annotation"></td>
           </tr>

--- a/templates/scripts/lists/users.php
+++ b/templates/scripts/lists/users.php
@@ -17,7 +17,6 @@
         {
             ?>
             <tr id="row_user" data-id="<?php echo $user['userID']?>" class="<?php echo $this->cycle(array('odd','even'))->next()?>">
-              <!--  option cell -->
               <td nowrap class="option">
                 <a href="#" onclick="lists_update_filter('user',<?php echo $user['userID']?>); $(this).blur(); return false;"><img
                         src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/filter.png' width='13' height='13'
@@ -25,12 +24,10 @@
                 </a>
               </td>
 
-              <!-- name cell -->
               <td width="100%" class="clients">
                 <?php echo $this->escape($user['name']) ?>
               </td>
 
-              <!-- annotation cell -->
               <td nowrap class="annotation"></td>
             </tr>
             <?php


### PR DESCRIPTION
FIXES #430

Changes proposed in this pull request:
- automatically hide projects, if the linked customer is hidden
- removed never touched code and silly html comments
- some phpdoc and code style changes on the fly
- show projects as hidden in admin if customer is hidden
- hide projects and customers in floater select boxes (unless they are linked in existing entries)
