### PR TITLE
Remove permission log spam

### DIFF
--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -4814,7 +4814,10 @@ class Kimai_Database_Mysql
 
         $result = $this->conn->RowCount() > 0;
 
+        /*
+        // TODO should we add a setting for debugging permissions?
         Kimai_Logger::logfile("Global role $roleID gave " . ($result ? 'true' : 'false') . " for $permission.");
+        */
         return $result;
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- do not spam the debug log with permission messages 

Reason for this pull request:
- log file is not for "regular use", but for exception and error messages
