### PR TITLE
fixed none-working export feature "print html table"

### DIFF
--- a/extensions/ki_export/floaters.php
+++ b/extensions/ki_export/floaters.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of
  * Kimai - Open Source Time Tracking // http://www.kimai.org
- * (c) 2006-2009 Kimai-Development-Team
+ * (c) Kimai-Development-Team since 2006
  *
  * Kimai is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,44 +25,48 @@ require("../../includes/kspi.php");
 switch ($axAction) {
 
     case "PDF":
-      $defaults = array('print_comments'=>1, 'print_summary'=>1, 'create_bookmarks'=>1, 'download_pdf'=>1,
-           'customer_new_page'=>0, 'reverse_order'=>0, 'pdf_format'=>'export_pdf', 'time_type'=>'dec_time');
-      $prefs = $database->user_get_preferences_by_prefix('ki_export.pdf.');
-      $view->prefs = array_merge($defaults, $prefs);
-      
-      echo $view->render("floaters/export_PDF.php"); 
-    break;
+        $defaults = array(
+            'print_comments' => 1,
+            'print_summary' => 1,
+            'create_bookmarks' => 1,
+            'download_pdf' => 1,
+            'customer_new_page' => 0,
+            'reverse_order' => 0,
+            'pdf_format' => 'export_pdf',
+            'time_type' => 'dec_time'
+        );
+        $prefs = $database->user_get_preferences_by_prefix('ki_export.pdf.');
+        $view->prefs = array_merge($defaults, $prefs);
 
-    case "XLS":  
-      $defaults = array('reverse_order'=>0);
-      $prefs = $database->user_get_preferences_by_prefix('ki_export.xls.');
-      $view->prefs = array_merge($defaults, $prefs);
+        echo $view->render("floaters/export_PDF.php");
+        break;
 
-      echo $view->render("floaters/export_XLS.php"); 
-    break;
+    case "XLS":
+        $defaults = array('reverse_order' => 0);
+        $prefs = $database->user_get_preferences_by_prefix('ki_export.xls.');
+        $view->prefs = array_merge($defaults, $prefs);
 
-    case "CSV":  
-      $defaults = array('column_delimiter'=>',', 'quote_char'=>'"', 'reverse_order'=>0);
-      $prefs = $database->user_get_preferences_by_prefix('ki_export.csv.');
-      $view->prefs = array_merge($defaults, $prefs);
+        echo $view->render("floaters/export_XLS.php");
+        break;
 
-      echo $view->render("floaters/export_CSV.php"); 
-    break;
+    case "CSV":
+        $defaults = array('column_delimiter' => ',', 'quote_char' => '"', 'reverse_order' => 0);
+        $prefs = $database->user_get_preferences_by_prefix('ki_export.csv.');
+        $view->prefs = array_merge($defaults, $prefs);
 
-    case "print":  
-      $defaults = array('print_summary'=>1, 'reverse_order'=>0);
-      $prefs = $database->user_get_preferences_by_prefix('ki_export.print.');
-      $view->prefs = array_merge($defaults, $prefs);
+        echo $view->render("floaters/export_CSV.php");
+        break;
 
-      echo $view->render("floaters/print.php"); 
-    break;
+    case "print":
+        $defaults = array('print_summary' => 1, 'reverse_order' => 0);
+        $prefs = $database->user_get_preferences_by_prefix('ki_export.print.');
+        $view->prefs = array_merge($defaults, $prefs);
 
-    case "help_timeformat":  
-      echo $view->render("floaters/help_timeformat.php"); 
-    break;
+        echo $view->render("floaters/print.php");
+        break;
+
+    case "help_timeformat":
+        echo $view->render("floaters/help_timeformat.php");
+        break;
 
 }
-
-?>
-
-    

--- a/extensions/ki_export/processor.php
+++ b/extensions/ki_export/processor.php
@@ -260,7 +260,7 @@ switch ($axAction) {
         $view->budgetSum = $budgetSum;
         $view->approvedSum = $approvedSum;
 
-        header("Content-Type: text/html");
+        header("Content-Type: text/html;charset=utf-8");
         echo $view->render("formats/html.php");
     break;
 

--- a/extensions/ki_export/templates/scripts/floaters/print.php
+++ b/extensions/ki_export/templates/scripts/floaters/print.php
@@ -37,7 +37,7 @@
                 </ul>
                 <div id="formbuttons">
                     <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>' onclick="floaterClose();return false;"/>
+                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>' onclick="floaterClose();"/>
                 </div>
             </fieldset>
         </form>


### PR DESCRIPTION
Changes proposed in this pull request:
- fix the submit button in the "print html table" floater in the export extension
- print the html table with utf-8 charset to be able to render all translations properly
- some minor code style changes

Reason for this pull request:
- feature was not working at all (probably this was only defect in some browser due to the "return false" statement)
