### PR TITLE
Using skin ViewHelper instead of $kga['conf'] directly

### DIFF
--- a/extensions/ext_debug/init.php
+++ b/extensions/ext_debug/init.php
@@ -33,9 +33,9 @@ $dir_ext = $settings['EXTENSION_DIR'];
 	$in = $timeframe[0];
 	$out = $timeframe[1];
 	
-$view = new Zend_View();
-$view->setBasePath(WEBROOT . 'extensions/' . $dir_ext . '/' . $dir_templates);
-	
+$view = new Kimai_View();
+$view->addBasePath(__DIR__ . '/templates/');
+
 // read kga --------------------------------------- 
 	$output = $kga;
     // clean out sone data that is way too private to be shown in the frontend ...

--- a/extensions/ext_debug/templates/scripts/index.php
+++ b/extensions/ext_debug/templates/scripts/index.php
@@ -20,7 +20,7 @@
 <div id="deb_ext_logfile_header">
     <div id="deb_ext_buttons">
 <?php if ($this->kga['delete_logfile']): ?>
-        <a href="#" title="Clear" onclick="deb_ext_clearLogfile();return false;"><img src="../skins/<?php echo $this->kga['conf']['skin'] ?>/grfx/button_trashcan.png" width="13" height="13" alt="Clear"></a>
+        <a href="#" title="Clear" onclick="deb_ext_clearLogfile();return false;"><img src="<?php echo $this->skin('grfx/button_trashcan.png') ?>" width="13" height="13" alt="Clear"></a>
 <?php endif; ?>
     </div>
     <strong>DEBUG LOGFILE</strong> <?php echo $this->limitText ?>

--- a/extensions/ki_adminpanel/processor.php
+++ b/extensions/ki_adminpanel/processor.php
@@ -424,14 +424,14 @@ switch ($axAction)
         // Ban a user from login
         $sts['active'] = 0;
         $database->user_edit($id, $sts);
-        echo sprintf("<img border='0' title='%s' alt='%s' src='../skins/%s/grfx/lock.png' width='16' height='16' />", $kga['lang']['banneduser'], $kga['lang']['banneduser'], $kga['conf']['skin']);
+        echo sprintf("<img border='0' title='%s' alt='%s' src='../skins/%s/grfx/lock.png' width='16' height='16' />", $kga['lang']['bannedUser'], $kga['lang']['bannedUser'], $view->skin()->getName());
         break;
 
     case "unbanUser" :
         // Unban a user from login
         $sts['active'] = 1;
         $database->user_edit($id, $sts);
-        echo sprintf("<img border='0' title='%s' alt='%s' src='../skins/%s/grfx/jipp.gif' width='16' height='16' />", $kga['lang']['activeAccount'], $kga['lang']['activeAccount'], $kga['conf']['skin']);
+        echo sprintf("<img border='0' title='%s' alt='%s' src='../skins/%s/grfx/jipp.gif' width='16' height='16' />", $kga['lang']['activeAccount'], $kga['lang']['activeAccount'], $view->skin()->getName());
         break;
 
     case "sendEditUser" :

--- a/extensions/ki_adminpanel/templates/scripts/activities.php
+++ b/extensions/ki_adminpanel/templates/scripts/activities.php
@@ -1,4 +1,4 @@
-<a href="#" onclick="floaterShow('floaters.php','add_edit_activity',0,0,500); $(this).blur(); return false;"><img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/add.png" width="22" height="16" alt="<?php echo $this->kga['lang']['new_activity']?>"></a> <?php echo $this->kga['lang']['new_activity']?>
+<a href="#" onclick="floaterShow('floaters.php','add_edit_activity',0,0,500); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->kga['lang']['new_activity']?>"></a> <?php echo $this->kga['lang']['new_activity']?>
 &nbsp;&nbsp;&nbsp;<?php echo $this->kga['lang']['view_filter']?>:
 <select size="1" id="activity_project_filter" onchange="adminPanel_extension_refreshSubtab('activities');">
 	<option value="-2" <?php if ($this->selected_activity_filter==-2): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['unassigned']?></option>
@@ -37,10 +37,10 @@
 			<tr class="<?php echo $this->cycle(array("odd","even"))->next()?>">
 				<td class="option">
 					<a href="#" onclick="editSubject('activity',<?php echo $activity['activityID']?>); $(this).blur(); return false;">
-						<img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif" width="13" height="13" alt="<?php echo $this->kga['lang']['edit']?>" title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
+						<img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['edit']?>" title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
 					&nbsp;
 					<a href="#" id="delete_activity<?php echo $activity['activityID']?>" onclick="adminPanel_extension_deleteActivity(<?php echo $activity['activityID']?>)">
-						<img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_trashcan.png" title="<?php echo $this->kga['lang']['delete_activity']?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_activity']?>" border="0"></a>
+						<img src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_activity']?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_activity']?>" border="0"></a>
 				</td>
 				<td class="activities <?php if ($isHidden) { echo 'hidden'; } ?>">
 					<?php echo $this->escape($activity['name']); ?>

--- a/extensions/ki_adminpanel/templates/scripts/customers.php
+++ b/extensions/ki_adminpanel/templates/scripts/customers.php
@@ -1,4 +1,4 @@
-<a href="#" onclick="floaterShow('floaters.php','add_edit_customer',0,0,450); $(this).blur(); return false;"><img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/add.png" width="22" height="16" alt="<?php echo $this->kga['lang']['new_customer']?>"></a> <?php echo $this->kga['lang']['new_customer']?>
+<a href="#" onclick="floaterShow('floaters.php','add_edit_customer',0,0,450); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->kga['lang']['new_customer']?>"></a> <?php echo $this->kga['lang']['new_customer']?>
 <br/><br/>
 <table>
 	<thead>
@@ -28,11 +28,11 @@
 			<tr class="<?php echo $this->cycle(array("odd","even"))->next()?>">
 				<td class="option">
 					<a href="#" onclick="editSubject('customer',<?php echo $row['customerID']?>); $(this).blur(); return false;"><img
-						src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif" width="13" height="13" alt="<?php echo $this->kga['lang']['edit']?>"
+						src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['edit']?>"
 						title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
 					&nbsp;
 					<a href="#" id="delete_customer<?php echo $row['customerID']?>" onclick="adminPanel_extension_deleteCustomer(<?php echo $row['customerID']?>)"><img
-						src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_trashcan.png" title="<?php echo $this->kga['lang']['delete_customer']?>"
+						src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_customer']?>"
 						width="13" height="13" alt="<?php echo $this->kga['lang']['delete_customer']?>" border="0"></a>
 				</td>
 				<td class="clients <?php if ($isHidden) { echo 'hidden'; } ?>">

--- a/extensions/ki_adminpanel/templates/scripts/floaters/edituser.php
+++ b/extensions/ki_adminpanel/templates/scripts/floaters/edituser.php
@@ -39,7 +39,7 @@
                         <input class="formfield" type="password" name="password" size="9" id="password"/> <?php echo $this->kga['lang']['minLength'] ?>
                         <?php if ($this->user_details['password'] == ""): ?>
                             <br/>
-                            <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/caution_mini.png" alt="Caution" valign="middle"/>
+                            <img src="<?php echo $this->skin('grfx/caution_mini.png'); ?>" alt="Caution" valign="middle"/>
                             <strong style="color:red"><?php echo $this->kga['lang']['nopasswordset'] ?></strong>
                         <?php endif; ?>
                     </li>
@@ -91,7 +91,7 @@
                             </td>
                             <td>
                                 <a class="deleteButton">
-                                    <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/close.png" width="22" height="16"/>
+                                    <img src="<?php echo $this->skin('grfx/close.png'); ?>" width="22" height="16"/>
                                 </a>
                             </td>
                         </tr>

--- a/extensions/ki_adminpanel/templates/scripts/globalRoles.php
+++ b/extensions/ki_adminpanel/templates/scripts/globalRoles.php
@@ -27,14 +27,14 @@
             <tr class='<?php echo $this->cycle(array("odd", "even"))->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editGlobalRole('<?php echo $globalRole['globalRoleID'] ?>'); $(this).blur(); return false;">
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/edit2.gif" title="<?php echo $this->kga['lang']['editGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editGlobalRole'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editGlobalRole'] ?>" border="0"></a>
                     &nbsp;
                     <?php if ($globalRole['count_users'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteGlobalRole(<?php echo $globalRole['globalRoleID'] ?>)"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan.png"
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>"
                                 title="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan_.png" title="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/groups.php
+++ b/extensions/ki_adminpanel/templates/scripts/groups.php
@@ -27,14 +27,14 @@
             <tr class='<?php echo $this->cycle(array("odd", "even"))->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editGroup('<?php echo $grouparray['groupID'] ?>'); $(this).blur(); return false;">
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/edit2.gif" title="<?php echo $this->kga['lang']['editGroup'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editGroup'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editGroup'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editGroup'] ?>" border="0"></a>
                     &nbsp;
                     <?php if ($grouparray['count_users'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteGroup(<?php echo $grouparray['groupID'] ?>)"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan.png"
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>"
                                 title="<?php echo $this->kga['lang']['delete_group'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_group'] ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan_.png" title="<?php echo $this->kga['lang']['delete_group'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_group'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['delete_group'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_group'] ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/membershipRoles.php
+++ b/extensions/ki_adminpanel/templates/scripts/membershipRoles.php
@@ -27,14 +27,14 @@
             <tr class='<?php echo $this->cycle(array("odd", "even"))->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editMembershipRole('<?php echo $membershipRole['membershipRoleID'] ?>'); $(this).blur(); return false;">
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/edit2.gif" title="<?php echo $this->kga['lang']['editMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editMembershipRole'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editMembershipRole'] ?>" border="0"></a>
                     &nbsp;
                     <?php if ($membershipRole['count_users'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteMembershipRole(<?php echo $membershipRole['membershipRoleID'] ?>)"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan.png"
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>"
                                 title="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan_.png" title="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/projects.php
+++ b/extensions/ki_adminpanel/templates/scripts/projects.php
@@ -1,4 +1,4 @@
-<a href="#" onclick="floaterShow('floaters.php', 'add_edit_project', 0, 0, 650); $(this).blur(); return false;"><img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/add.png" width="22" height="16" alt="<?php echo $this->kga['lang']['new_project']?>"></a>
+<a href="#" onclick="floaterShow('floaters.php', 'add_edit_project', 0, 0, 650); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->kga['lang']['new_project']?>"></a>
 <?php echo $this->kga['lang']['new_project']?><br/><br/>
 <table>
 <thead>
@@ -33,11 +33,11 @@
 			<tr class="<?php echo $this->cycle(array("odd","even"))->next()?>">
 				<td class="option">
 					<a href="#" onclick="editSubject('project',<?php echo $row['projectID']?>); $(this).blur(); return false;"><img
-						src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif" width="13" height="13"
+						src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13"
 						alt="<?php echo $this->kga['lang']['edit']?>" title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
 					&nbsp;
 					<a href="#" id="delete_project<?php echo $row['projectID']?>" onclick="adminPanel_extension_deleteProject(<?php echo $row['projectID']?>)"><img
-						src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_trashcan.png" title="<?php echo $this->kga['lang']['delete_project']?>"
+						src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_project']?>"
 						width="13" height="13" alt="<?php echo $this->kga['lang']['delete_project']?>" border="0"></a>
 				</td>
 				<?php if ($this->kga['conf']['flip_project_display']): ?>

--- a/extensions/ki_adminpanel/templates/scripts/status.php
+++ b/extensions/ki_adminpanel/templates/scripts/status.php
@@ -27,15 +27,15 @@
             <tr class='<?php echo $this->cycle(array("odd", "even"))->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editStatus('<?php echo $statusarray['statusID'] ?>'); $(this).blur(); return false;"><img
-                            src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/edit2.gif" title="<?php echo $this->kga['lang']['editstatus'] ?>"
+                            src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editstatus'] ?>"
                             width="13" height="13" alt="<?php echo $this->kga['lang']['editstatus'] ?>" border="0"></a>
                     &nbsp;
                     <?php if ($statusarray['timeSheetEntryCount'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteStatus(<?php echo $statusarray['statusID'] ?>)"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan.png" title="<?php echo $this->kga['lang']['delete_status'] ?>"
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_status'] ?>"
                                 width="13" height="13" alt="<?php echo $this->kga['lang']['delete_status'] ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan_.png" title="<?php echo $this->kga['lang']['delete_status'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_status'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['delete_status'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_status'] ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/users.php
+++ b/extensions/ki_adminpanel/templates/scripts/users.php
@@ -35,22 +35,22 @@
                 <?php /* ########## Option cells ########## */ ?>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editUser('<?php echo $userarray['userID'] ?>'); $(this).blur(); return false;">
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/edit2.gif" title="<?php echo $this->kga['lang']['editUser'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editUser'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editUser'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editUser'] ?>" border="0"></a>
                     &nbsp;
                     <?php if ($userarray['mail']): ?>
                         <a href="mailto:<?php echo $this->escape($userarray['mail']); ?>"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_mail.gif"
+                                src="<?php echo $this->skin('grfx/button_mail.gif'); ?>"
                                 title="<?php echo $this->kga['lang']['mailUser'] ?>" width="12" height="13" alt="<?php echo $this->kga['lang']['mailUser'] ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_mail_.gif" title="<?php echo $this->kga['lang']['mailUser'] ?>" width="12" height="13" alt="<?php echo $this->kga['lang']['mailUser'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_mail_.gif'); ?>" title="<?php echo $this->kga['lang']['mailUser'] ?>" width="12" height="13" alt="<?php echo $this->kga['lang']['mailUser'] ?>" border="0">
                     <?php endif; ?>
                     &nbsp;
                     <?php if ($this->curr_user != $userarray['name']) { ?>
                         <a href="#" id="deleteUser<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_deleteUser(<?php echo $userarray['userID'] ?>, <?php echo($userarray['trash'] ? "2" : "1"); ?>)"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan.png" title="<?php echo $this->kga['lang']['deleteUser'] ?>"
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['deleteUser'] ?>"
                                 width="13" height="13" alt="<?php echo $this->kga['lang']['deleteUser'] ?>" border="0"></a>
                     <?php } else { ?>
-                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan_.png" title="<?php echo $this->kga['lang']['deleteUser'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteUser'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['deleteUser'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteUser'] ?>" border="0">
                     <?php } ?>
                 </td>
 
@@ -70,25 +70,25 @@
                     <?php if ($userarray['active'] == 1): ?>
                         <?php if ($this->curr_user != $userarray['name']): ?>
                             <a href="#" id="ban<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_banUser('<?php echo $userarray['userID'] ?>'); return false;">
-                                <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/jipp.gif' alt='<?php echo $this->kga['lang']['activeAccount'] ?>' title='<?php echo $this->kga['lang']['activeAccount'] ?>' border="0" width="16" height="16"/></a>
+                                <img src="<?php echo $this->skin('grfx/jipp.gif'); ?>" alt='<?php echo $this->kga['lang']['activeAccount'] ?>' title='<?php echo $this->kga['lang']['activeAccount'] ?>' border="0" width="16" height="16"/></a>
                         <?php else: ?>
-                            <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/jipp_.gif' alt='<?php echo $this->kga['lang']['activeAccount'] ?>' title='<?php echo $this->kga['lang']['activeAccount'] ?>' border="0" width="16" height="16"/>
+                            <img src="<?php echo $this->skin('grfx/jipp_.gif'); ?>" alt='<?php echo $this->kga['lang']['activeAccount'] ?>' title='<?php echo $this->kga['lang']['activeAccount'] ?>' border="0" width="16" height="16"/>
                         <?php endif; ?>
                     <?php endif; ?>
 
                     <?php if ($userarray['active'] == 0): ?>
                         <a href="#" id="ban<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_unbanUser('<?php echo $userarray['userID'] ?>'); return false;">
-                            <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/lock.png' alt='<?php echo $this->kga['lang']['bannedUser'] ?>' title='<?php echo $this->kga['lang']['bannedUser'] ?>' border="0" width="16" height="16"/></a>
+                            <img src="<?php echo $this->skin('grfx/lock.png'); ?>" alt='<?php echo $this->kga['lang']['bannedUser'] ?>' title='<?php echo $this->kga['lang']['bannedUser'] ?>' border="0" width="16" height="16"/></a>
                     <?php endif; ?>
                     &nbsp;
                     <?php if ($userarray['passwordSet'] == "no"): ?>
                         <a href="#" onclick="adminPanel_extension_editUser('<?php echo $userarray['userID'] ?>'); $(this).blur(); return false;">
-                            <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/caution_mini.png" width="16" height="16" title='<?php echo $this->kga['lang']['nopasswordset'] ?>' border="0"></a>
+                            <img src="<?php echo $this->skin('grfx/caution_mini.png'); ?>" width="16" height="16" title='<?php echo $this->kga['lang']['nopasswordset'] ?>' border="0"></a>
                     <?php endif; ?>
                     &nbsp;
                     <?php if ($userarray['trash']): ?>
                         <a href="#" id="deleteUser<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_deleteUser(<?php echo $userarray['userID'] ?>, 0)"><img
-                                src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/button_trashcan.png" title="<?php echo $this->kga['lang']['restoreAccount'] ?>"
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['restoreAccount'] ?>"
                                 width="13" height="13" alt="<?php echo $this->kga['lang']['restoreAccount'] ?>" border="0"></a>
                     <?php endif; ?>
                 </td>

--- a/extensions/ki_expenses/templates/scripts/expenses.php
+++ b/extensions/ki_expenses/templates/scripts/expenses.php
@@ -39,11 +39,11 @@ if ($this->expenses)
 
             <?php if (isset($this->kga['user']) &&  ($this->kga['conf']['editLimit'] == "-" || time()-$row['timestamp'] <= $this->kga['conf']['editLimit'])): ?>
                 <a href ='#' onclick="expense_editRecord(<?php echo $row['expenseID']?>); $(this).blur(); return false;" title='<?php echo $this->kga['lang']['edit']?>'>
-                <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif' width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border='0' /></a>
+                <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border='0' /></a>
 
                 <?php if ($this->kga['conf']['quickdelete'] > 0): ?>
                     <a href ='#' class='quickdelete' onclick="expense_quickdelete(<?php echo $row['expenseID']?>); return false;">
-                    <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_trashcan.png' width='13' height='13' alt='<?php echo $this->kga['lang']['quickdelete']?>' title='<?php echo $this->kga['lang']['quickdelete']?>' border=0 />
+                    <img src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['quickdelete']?>' title='<?php echo $this->kga['lang']['quickdelete']?>' border=0 />
                     </a>
                 <?php endif; ?>
             <?php endif; ?>
@@ -107,11 +107,11 @@ if ($this->expenses)
 
             <?php if ($row['comment']): ?>
                 <?php if ($row['commentType'] == '0'): ?>
-                            <a href="#" onclick="comment(<?php echo $row['expenseID']?>); $(this).blur(); return false;"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase.gif' width="12" height="13" title='<?php echo $this->escape($row['comment']);?>' border="0" /></a>
+                    <a href="#" onclick="comment(<?php echo $row['expenseID']?>); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/blase.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['comment']);?>' border="0" /></a>
                 <?php elseif ($row['commentType'] == '1'): ?>
-                            <a href="#" onclick="comment(<?php echo $row['expenseID']?>); $(this).blur(); return false;"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase_sys.gif' width="12" height="13" title='<?php echo $this->escape($row['comment']);?>' border="0" /></a>
+                    <a href="#" onclick="comment(<?php echo $row['expenseID']?>); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/blase_sys.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['comment']);?>' border="0" /></a>
                 <?php elseif ($row['commentType'] == '2'): ?>
-                            <a href="#" onclick="comment(<?php echo $row['expenseID']?>); $(this).blur(); return false;"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase_caution.gif' width="12" height="13" title='<?php echo $this->escape($row['comment']);?>' border="0" /></a>
+                    <a href="#" onclick="comment(<?php echo $row['expenseID']?>); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/blase_caution.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['comment']);?>' border="0" /></a>
                 <?php endif; ?>
             <?php endif; ?>
             </td>

--- a/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -79,14 +79,14 @@ if ($this->timeSheetEntries)
 
             <?php if ($this->kga['show_RecordAgain']): ?>
               <a onclick="ts_ext_recordAgain(<?php echo $row['projectID']?>,<?php echo $row['activityID']?>,<?php echo $row['timeEntryID']?>); return false;"
-                 href ="#" class="recordAgain"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_recordthis.gif'
+                 href ="#" class="recordAgain"><img src="<?php echo $this->skin('grfx/button_recordthis.gif'); ?>"
                  width='13' height='13' alt='<?php echo $this->kga['lang']['recordAgain']?>' title='<?php echo $this->kga['lang']['recordAgain']?> (ID:<?php echo $row['timeEntryID']?>)' border='0' /></a>
             <?php endif; ?>
 
         <?php else: ?>
 
             <a href ='#' class='stop' onclick="ts_ext_stopRecord(<?php echo $row['timeEntryID']?>); return false;"><img
-                    src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_stopthis.gif' width='13'
+                    src="<?php echo $this->skin('grfx/button_stopthis.gif'); ?>" width='13'
                     height='13' alt='<?php echo $this->kga['lang']['stop']?>' title='<?php echo $this->kga['lang']['stop']?> (ID:<?php echo $row['timeEntryID']?>)' border='0' /></a>
 
         <?php endif; ?>
@@ -96,7 +96,7 @@ if ($this->timeSheetEntries)
     //Edit Record Button ?>
         <a href ='#' onclick="editRecord(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"
            title='<?php echo $this->kga['lang']['edit']?>'><img
-           src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif' width='13' height='13'
+           src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13'
            alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border='0' /></a>
       <?php endif; ?>
 
@@ -104,14 +104,14 @@ if ($this->timeSheetEntries)
             //Edit quick-note Button ?>
             <a href='#' onclick="editQuickNote(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"
                title='<?php echo $this->kga['lang']['editNote']?>'><img 
-                    src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/editor_icon.png' width='14' height='14'
+                    src="<?php echo $this->skin('grfx/editor_icon.png'); ?>" width='14' height='14'
                     alt='<?php echo $this->kga['lang']['editNote']?>' title='<?php echo $this->kga['lang']['editNote']?>' border='0' /></a>
         <?php endif; ?>
 
       <?php if ($this->kga['conf']['quickdelete'] > 0):
     // quick erase trashcan  ?>
         <a href ='#' class='quickdelete' onclick="quickdelete(<?php echo $row['timeEntryID']?>); return false;"><img
-            src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/button_trashcan.png' width='13'
+            src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" width='13'
             height='13' alt='<?php echo $this->kga['lang']['quickdelete']?>' title='<?php echo $this->kga['lang']['quickdelete']?>'
             border=0 /></a>
       <?php endif; ?>
@@ -184,11 +184,11 @@ if ($this->timeSheetEntries)
 
                 <?php if ($row['comment']): ?>
                     <?php if ($row['commentType'] == '0'): ?>
-                                        <a href="#" onclick="ts_comment(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase.gif' width="12" height="13" title='<?php echo $this->escape($row['comment'])?>' border="0" /></a>
+                        <a href="#" onclick="ts_comment(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/blase.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['comment'])?>' border="0" /></a>
                     <?php elseif ($row['commentType'] == '1'): ?>
-                                        <a href="#" onclick="ts_comment(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase_sys.gif' width="12" height="13" title='<?php echo $this->escape($row['comment'])?>' border="0" /></a>
+                        <a href="#" onclick="ts_comment(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/blase_sys.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['comment'])?>' border="0" /></a>
                     <?php elseif ($row['commentType'] == '2'): ?>
-                                        <a href="#" onclick="ts_comment(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase_caution.gif' width="12" height="13" title='<?php echo $this->escape($row['comment'])?>' border="0" /></a>
+                        <a href="#" onclick="ts_comment(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/blase_caution.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['comment'])?>' border="0" /></a>
                     <?php endif; ?>
                 <?php endif; ?>
             </td>
@@ -197,7 +197,7 @@ if ($this->timeSheetEntries)
             <td class="description <?php echo $tdClass; ?>" >
               <?php echo $this->escape($this->truncate($row['description'],50,'...')) ?>
                 <?php if ($row['description']): ?>
-                <a href="#" onclick="$(this).blur();  return false;" ><img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/blase_sys.gif' width="12" height="13" title='<?php echo $this->escape($row['description'])?>' border="0" /></a>
+                <a href="#" onclick="$(this).blur();  return false;" ><img src="<?php echo $this->skin('grfx/blase_sys.gif'); ?>" width="12" height="13" title='<?php echo $this->escape($row['description'])?>' border="0" /></a>
               <?php endif; ?>
             </td>
             <td class="trackingnumber <?php echo $tdClass; ?>">

--- a/templates/helpers/Skin.php
+++ b/templates/helpers/Skin.php
@@ -24,16 +24,27 @@
  */
 class Zend_View_Helper_Skin extends Zend_View_Helper_Abstract
 {
+    protected $fileName = null;
+
     /**
      * @param string $file
      * @return string
      */
     public function skin($file = null)
     {
-        $url = '../skins/' . $this->getSkinName() . '/';
-
         if ($file !== null) {
-            $url .= $file;
+            $this->fileName = $file;
+        }
+
+        return $this;
+    }
+
+    public function __toString()
+    {
+        $url = '../skins/' . $this->getName() . '/';
+
+        if ($this->fileName !== null) {
+            $url .= $this->fileName;
         }
 
         return $url;
@@ -42,7 +53,7 @@ class Zend_View_Helper_Skin extends Zend_View_Helper_Abstract
     /**
      * @return string
      */
-    protected function getSkinName()
+    public function getName()
     {
         $skin = Kimai_Config::getDefault(Kimai_Config::DEFAULT_SKIN);
 

--- a/templates/scripts/core/main.php
+++ b/templates/scripts/core/main.php
@@ -50,7 +50,7 @@
 
     <script type="text/javascript"> 
     
-        var skin ="<?php echo $this->escape($this->kga['conf']['skin']); ?>";
+        var skin ="<?php echo $this->escape($this->skin()->getName()); ?>";
 
         var lang_checkUsername    = "<?php echo $this->escape($this->kga['lang']['checkUsername']); ?>";
         var lang_checkGroupname   = "<?php echo $this->escape($this->kga['lang']['checkGroupname']); ?>";
@@ -187,12 +187,12 @@
     <div id="top">
         
         <div id="logo">
-            <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/g3_logo.png" width="151" height="52" alt="Logo" />
+            <img src="<?php echo $this->skin('grfx/g3_logo.png'); ?>" width="151" height="52" alt="Logo" />
         </div>
         
         <div id="menu">
-            <a id="main_logout_button" href="../index.php?a=logout"><img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/g3_menu_logout.png" width="36" height="27" alt="Logout" /></a>
-            <a id="main_tools_button" href="#" ><img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/g3_menu_dropdown.png" width="44" height="27" alt="Menu Dropdown" /></a>
+            <a id="main_logout_button" href="../index.php?a=logout"><img src="<?php echo $this->skin('grfx/g3_menu_logout.png'); ?>" width="36" height="27" alt="Logout" /></a>
+            <a id="main_tools_button" href="#" ><img src="<?php echo $this->skin('grfx/g3_menu_dropdown.png'); ?>" width="44" height="27" alt="Menu Dropdown" /></a>
             <br/><?php echo $this->kga['lang']['logged_in_as']?> <b><?php echo isset($this->kga['user']) ? $this->escape($this->kga['user']['name']) : $this->escape($this->kga['customer']['name'])?></b>
         </div>
         
@@ -240,10 +240,10 @@
 
           <div id="infos">
               <span id="n_date"></span>&nbsp;
-              <a href="#" title="<?php echo $this->escape($this->kga['lang']['now']);?>" onclick="setTimeframe(new Date(),new Date()); return false;"><img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']);?>/grfx/timeframe_now.png" width="12" height="14" alt="Select date of today" /></a>&nbsp;
-              <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']);?>/grfx/g3_display_smallclock.png" width="13" height="13" alt="Display Smallclock" />
+              <a href="#" title="<?php echo $this->escape($this->kga['lang']['now']);?>" onclick="setTimeframe(new Date(),new Date()); return false;"><img src="<?php echo $this->skin('grfx/timeframe_now.png'); ?>" width="12" height="14" alt="Select date of today" /></a>&nbsp;
+              <img src="<?php echo $this->skin('grfx/g3_display_smallclock.png'); ?>" width="13" height="13" alt="Display Smallclock" />
               <span id="n_uhr">00:00</span> &nbsp; 
-              <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/g3_display_eye.png" width="15" height="12" alt="Display Eye" />
+              <img src="<?php echo $this->skin('grfx/g3_display_eye.png'); ?>" width="15" height="12" alt="Display Eye" />
               <strong id="display_total"><?php echo $this->total?></strong> 
           </div>
         </div> 

--- a/templates/scripts/floaters/add_edit_project.php
+++ b/templates/scripts/floaters/add_edit_project.php
@@ -110,7 +110,7 @@
                                 </td>
                                 <td>
                                     <a class="deleteButton">
-                                        <img src="../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/close.png" width="22" height="16"/>
+                                        <img src="<?php echo $this->skin('grfx/close.png'); ?>" width="22" height="16"/>
                                     </a>
                                 </td>
                             </tr>

--- a/templates/scripts/floaters/preferences.php
+++ b/templates/scripts/floaters/preferences.php
@@ -32,7 +32,7 @@
                 <ul>
                     <li>
                         <label for="skin"><?php echo $this->kga['lang']['skin'] ?>:</label>
-                        <?php echo $this->formSelect('skin', $this->kga['conf']['skin'], null, $this->skins); ?>
+                        <?php echo $this->formSelect('skin', $this->skin()->getName(), null, $this->skins); ?>
                     </li>
                     <li>
                         <label for="password"><?php echo $this->kga['lang']['newPassword'] ?>:</label>

--- a/templates/scripts/lists/activities.php
+++ b/templates/scripts/lists/activities.php
@@ -25,16 +25,16 @@ $activities = $this->filterListEntries($this->activities);
                 <td nowrap class="option">
                     <?php if ($this->show_activity_edit_button): ?>
                     <a href="#" onclick="editSubject('activity',<?php echo $activity['activityID']?>); $(this).blur(); return false;">
-                      <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/edit2.gif' width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?> (ID:<?php echo $activity['activityID']?>)' border='0' />
+                      <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?> (ID:<?php echo $activity['activityID']?>)' border='0' />
                     </a>
                     <?php endif; ?>
 
                     <a href="#" onclick="lists_update_filter('activity',<?php echo $activity['activityID']?>); $(this).blur(); return false;">
-                      <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/filter.png' width='13' height='13' alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
+                      <img src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
                     </a>
 
                     <a href="#" class="preselect" onclick="buzzer_preselect_activity(<?php echo $activity['activityID']?>,'<?php echo $this->jsEscape($activity['name'])?>'); return false;" id="ps<?php echo $activity['activityID']?>">
-                      <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin']) ?>/grfx/preselect_off.png' width='13' height='13' alt='<?php echo $this->kga['lang']['select']?>' title='<?php echo $this->kga['lang']['select']?> (ID:<?php echo $activity['activityID']?>)' border='0' />
+                      <img src="<?php echo $this->skin('grfx/preselect_off.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['select']?>' title='<?php echo $this->kga['lang']['select']?> (ID:<?php echo $activity['activityID']?>)' border='0' />
                     </a>
                 </td>
 

--- a/templates/scripts/lists/customers.php
+++ b/templates/scripts/lists/customers.php
@@ -25,11 +25,11 @@ $customers = $this->filterListEntries($this->customers);
               <td nowrap class="option">
                 <?php if ($this->show_customer_edit_button): ?>
                 <a href="#" onclick="editSubject('customer',<?php echo $customer['customerID']?>); $(this).blur(); return false;">
-                  <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif' width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border='0' />
+                  <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border='0' />
                 </a>
                 <?php endif; ?>
                 <a href="#" onclick="lists_update_filter('customer',<?php echo $customer['customerID']?>); $(this).blur(); return false;">
-                  <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/filter.png' width='13' height='13' alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
+                  <img src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
                 </a>
               </td>
 

--- a/templates/scripts/lists/projects.php
+++ b/templates/scripts/lists/projects.php
@@ -25,14 +25,14 @@ $projects = $this->filterListEntries($this->projects);
 
                 <?php if ($this->show_project_edit_button): ?>
                 <a href="#" onclick="editSubject('project',<?php echo $project['projectID']?>); $(this).blur(); return false;">
-                  <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/edit2.gif' width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?> (ID:<?php echo $project['projectID']?>)' border='0' />
+                  <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?> (ID:<?php echo $project['projectID']?>)' border='0' />
                 </a>
                 <?php endif; ?>
                 <a href="#" onclick="lists_update_filter('project',<?php echo $project['projectID']?>); $(this).blur(); return false;">
-                  <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/filter.png' width='13' height='13' alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
+                  <img src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
                 </a>
                 <a href="#" class="preselect" onclick="buzzer_preselect_project(<?php echo $project['projectID']?>,'<?php echo $this->jsEscape($project['name'])?>',<?php echo $project['customerID']?>,'<?php echo $this->jsEscape($project['customerName'])?>'); return false;" id="ps<?php echo $project['projectID']?>">
-                  <img src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/preselect_off.png' width='13' height='13' alt='<?php echo $this->kga['lang']['select']?>' title='<?php echo $this->kga['lang']['select']?> (ID:<?php echo $project['projectID']?>)' border='0' />
+                  <img src="<?php echo $this->skin('grfx/preselect_off.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['select']?>' title='<?php echo $this->kga['lang']['select']?> (ID:<?php echo $project['projectID']?>)' border='0' />
                 </a>
             </td>
 

--- a/templates/scripts/lists/users.php
+++ b/templates/scripts/lists/users.php
@@ -19,7 +19,7 @@
             <tr id="row_user" data-id="<?php echo $user['userID']?>" class="<?php echo $this->cycle(array('odd','even'))->next()?>">
               <td nowrap class="option">
                 <a href="#" onclick="lists_update_filter('user',<?php echo $user['userID']?>); $(this).blur(); return false;"><img
-                        src='../skins/<?php echo $this->escape($this->kga['conf']['skin'])?>/grfx/filter.png' width='13' height='13'
+                        src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13'
                         alt='<?php echo $this->kga['lang']['filter']?>' title='<?php echo $this->kga['lang']['filter']?>' border='0' />
                 </a>
               </td>


### PR DESCRIPTION
Changes proposed in this pull request:
- using the skin viewhelper everywhere, instead of accessing the kga['conf'] array directly
- added __toString() for skin view helper
- fixed banneduser translation in admin
