### PR TITLE
Use server time in startRecord (resolves #507), cleanup

### DIFF
--- a/core/processor.php
+++ b/core/processor.php
@@ -144,7 +144,7 @@ switch ($axAction) {
         }
     
         $IDs = explode('|', $axValue);
-        $newID = $database->startRecorder($IDs[0], $IDs[1], $id, $_REQUEST['startTime']);
+        $newID = $database->startRecorder($IDs[0], $IDs[1], $id);
         echo json_encode(array(
           'id' =>  $newID
         ));

--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -278,8 +278,7 @@ function ts_ext_recordAgain(project,activity,id) {
     $('#timeSheetEntry'+id+'>td>a.recordAgain>img').attr("src","../skins/"+skin+"/grfx/loading13.gif");
     hour=0;min=0;sec=0;
     now = Math.floor(((new Date()).getTime())/1000);
-    offset = now;
-    startsec = 0;
+    startsec = now - offset;
     show_stopwatch();
     $('#timeSheetEntry'+id+'>td>a').removeAttr('onclick');
 

--- a/js/main.js
+++ b/js/main.js
@@ -337,11 +337,10 @@ function updateTimeframeWarning() {
 function startRecord(projectID,activityID,userID) {
     hour=0;min=0;sec=0;
     now = Math.floor(((new Date()).getTime())/1000);
-    offset = 0;
-    startsec = now;
+    startsec = now - offset;
     show_stopwatch();
     value = projectID +"|"+ activityID;
-    $.post("processor.php", { axAction: "startRecord", axValue: value, id: userID, startTime: now},
+    $.post("processor.php", { axAction: "startRecord", axValue: value, id: userID},
         function(response){
             var data = jQuery.parseJSON(response);
             currentRecording = data['id'];
@@ -480,8 +479,7 @@ function buzzer_preselect_update_ui(selector,selectedID,updateRecording) {
 // ... so just THX! ;)
 
 function ticktac() {
-    startsecoffset = startsec ? startsec : offset;
-    sek   = Math.floor((new Date()).getTime()/1000)-startsecoffset;
+    sek   = Math.floor((new Date()).getTime()/1000) - startsec - offset;
     hour  = Math.floor(sek / 3600);
     min   = Math.floor((sek-hour*3600) / 60);
     sec   = Math.floor(sek-hour*3600-min*60);

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -3596,20 +3596,18 @@ class Kimai_Database_Mysql
      * @param integer $projectID ID of project to record
      * @param $activityID
      * @param $user
-     * @param $startTime
      * @return int id of the new entry or false on failure
      * @author th, sl
      */
-    public function startRecorder($projectID, $activityID, $user, $startTime)
+    public function startRecorder($projectID, $activityID, $user)
     {
         $projectID = MySQL::SQLValue($projectID, MySQL::SQLVALUE_NUMBER);
         $activityID = MySQL::SQLValue($activityID, MySQL::SQLVALUE_NUMBER);
         $user = MySQL::SQLValue($user, MySQL::SQLVALUE_NUMBER);
-        $startTime = MySQL::SQLValue($startTime, MySQL::SQLVALUE_NUMBER);
 
         $values['projectID'] = $projectID;
         $values['activityID'] = $activityID;
-        $values['start'] = $startTime;
+        $values['start'] = time();
         $values['userID'] = $user;
         $values['statusID'] = $this->kga['conf']['defaultStatusID'];
 

--- a/libraries/Kimai/Remote/Api.php
+++ b/libraries/Kimai/Remote/Api.php
@@ -267,7 +267,7 @@ class Kimai_Remote_Api
         }
         */
 
-        $result = $this->getBackend()->startRecorder($projectId, $activityId, $uid, time());
+        $result = $this->getBackend()->startRecorder($projectId, $activityId, $uid);
         if ($result) {
             return $this->getSuccessResult(array());
         } else {


### PR DESCRIPTION
FIXES #507, #266, #403

Changes proposed in this pull request:
- Use server time in startRecord
- Adjust offset for ticktac (Buzzer)
- "offset" is timediff between server and local, only set ones on page load
- "startsec" is server time
- "now" is local time

Reason for this pull request:
- Fix different time base for start and stop timer

How to test:
1. Force a timediff between server and your local system. For example set your local time 1 hour in future of _same_ timezone. Set local time 14:00 CET, if the server time is 13:00 CET.
2. Press start and stop in same minute ( <60 sec)
3. Failed with old code recorded: In=14:00 Out=13:00 h'm=-1:00 rate=-1,00
4. After this patch recorded: In=13:00 Out=13:00 h'm=0:00 rate=0,00
