### PR TITLE
Ticktac 00 optimized

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -488,18 +488,9 @@ function ticktac() {
     
     if (sec==60) { sec=0; min++; }
     if (min > 59) { min = 0; hour++; }
-    if (sec==0) $("#s").html("00");
-    else {
-        $("#s").html(((sec<10)?"0":"")+sec);
-    }
-    if (min==0) $("#m").html("00");
-    else {
-        $("#m").html(((min<10)?"0":"")+min);
-     }
-    if (hour==0) $("#h").html("00");
-    else {
-        $("#h").html(((hour<10)?"0":"")+hour);
-    }
+    $("#s").html(((sec<10)?"0":"")+sec);
+    $("#m").html(((min<10)?"0":"")+min);
+    $("#h").html(((hour<10)?"0":"")+hour);
 
     htmp = $("#h").html();
     mtmp = $("#m").html();


### PR DESCRIPTION
FIXES nothing, only an optimization

Changes proposed in this pull request:
- Remove special detection for "00" in stopwatch

Reason for this pull request:
- If the number is 0, then the string "0" will be add to to integer 0. The result is a "00".
- Not need to check the "00" as special case.
