### PR TITLE
ticktac: Use modulo and trunc for integer division

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -473,18 +473,11 @@ function ticktac() {
 
     // Split total seconds from start time to current time into
     // separate variables for viewing hours:minutes:seconds
-    var hours   = Math.floor(total_seconds / 3600);
-    var minutes = Math.floor((total_seconds - hours * 3600) / 60);
-    var seconds = Math.floor(total_seconds - hours * 3600 - minutes * 60);
+    var total_minutes = Math.trunc(total_seconds / 60);
 
-    if (seconds == 60) {
-        seconds = 0;
-        minutes++;
-    }
-    if (minutes > 59) {
-        minutes = 0;
-        hours++;
-    }
+    var hours = Math.trunc(total_minutes / 60);
+    var minutes = total_minutes % 60;
+    var seconds = total_seconds % 60;
 
     $("#s").html(prependZeroIfNeeded(seconds));
     $("#m").html(prependZeroIfNeeded(minutes));


### PR DESCRIPTION
code optimization

Changes proposed in this pull request:
- Use step by step modulo operator for integer division
- Use `trunc` to get the integral part from number 

Reason for this pull request:
- Not need to check the case, if minute or hour is 60 or grater 59
- `floor` rounds down, `trunc` strips all from right side of comma.
- `floor` makes a different for negative numbers, that of curse we should never have here.
  Example `Math.floor(-1.2) => 2`  and `Math.trunc(-1.2) => 1` [refer mozilla.org](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc)
