### PR TITLE
Use server time in startRecord (resolves #507)

### DIFF
--- a/core/processor.php
+++ b/core/processor.php
@@ -144,7 +144,7 @@ switch ($axAction) {
         }
     
         $IDs = explode('|', $axValue);
-        $newID = $database->startRecorder($IDs[0], $IDs[1], $id, $_REQUEST['startTime']);
+        $newID = $database->startRecorder($IDs[0], $IDs[1], $id);
         echo json_encode(array(
           'id' =>  $newID
         ));

--- a/js/main.js
+++ b/js/main.js
@@ -341,7 +341,7 @@ function startRecord(projectID,activityID,userID) {
     startsec = now;
     show_stopwatch();
     value = projectID +"|"+ activityID;
-    $.post("processor.php", { axAction: "startRecord", axValue: value, id: userID, startTime: now},
+    $.post("processor.php", { axAction: "startRecord", axValue: value, id: userID},
         function(response){
             var data = jQuery.parseJSON(response);
             currentRecording = data['id'];

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -3596,20 +3596,18 @@ class Kimai_Database_Mysql
      * @param integer $projectID ID of project to record
      * @param $activityID
      * @param $user
-     * @param $startTime
      * @return int id of the new entry or false on failure
      * @author th, sl
      */
-    public function startRecorder($projectID, $activityID, $user, $startTime)
+    public function startRecorder($projectID, $activityID, $user)
     {
         $projectID = MySQL::SQLValue($projectID, MySQL::SQLVALUE_NUMBER);
         $activityID = MySQL::SQLValue($activityID, MySQL::SQLVALUE_NUMBER);
         $user = MySQL::SQLValue($user, MySQL::SQLVALUE_NUMBER);
-        $startTime = MySQL::SQLValue($startTime, MySQL::SQLVALUE_NUMBER);
 
         $values['projectID'] = $projectID;
         $values['activityID'] = $activityID;
-        $values['start'] = $startTime;
+        $values['start'] = time();
         $values['userID'] = $user;
         $values['statusID'] = $this->kga['conf']['defaultStatusID'];
 

--- a/libraries/Kimai/Remote/Api.php
+++ b/libraries/Kimai/Remote/Api.php
@@ -267,7 +267,7 @@ class Kimai_Remote_Api
         }
         */
 
-        $result = $this->getBackend()->startRecorder($projectId, $activityId, $uid, time());
+        $result = $this->getBackend()->startRecorder($projectId, $activityId, $uid);
         if ($result) {
             return $this->getSuccessResult(array());
         } else {


### PR DESCRIPTION
FIXES #507, #266, #403, #474

Changes proposed in this pull request:
- Use server time in startRecord 

Reason for this pull request:
- Fix different time base for start and stop timer

How to test:
1. Force a timediff between server and your local system. For example set your local time 1 hour in future of _same_ timezone. Set local time 14:00 CET, if the server time is 13:00 CET.
2. Press start and stop in same minute ( <60 sec)
3. Failed with old code recorded: In=14:00 Out=13:00 h'm=-1:00 rate=-1,00
4. After this patch recorded: In=13:00 Out=13:00 h'm=0:00 rate=0,00

_This is a subset of pull request #681. This request does not fix similar problem on stopwatch, which was moved into #685._
