### PR TITLE
startsec strict browser time based

### DIFF
--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -317,8 +317,7 @@ function ts_ext_recordAgain(project,activity,id) {
 
 	$('#timeSheetEntry' + id + '>td>a.recordAgain>img').attr("src", "../skins/" + skin + "/grfx/loading13.gif");
 	var now = Math.floor(((new Date()).getTime()) / 1000);
-	offset = now;
-	startsec = 0;
+	startsec = now;
 	show_stopwatch();
 	$('#timeSheetEntry'+id+'>td>a').removeAttr('onclick');
 

--- a/js/main.js
+++ b/js/main.js
@@ -325,8 +325,8 @@ function updateTimeframeWarning() {
 //
 function startRecord(projectID,activityID,userID) {
     var now = Math.floor(((new Date()).getTime()) / 1000);
-    offset = 0;
     startsec = now;
+    offset = 0;
     show_stopwatch();
     value = projectID +"|"+ activityID;
     $.post("processor.php", { axAction: "startRecord", axValue: value, id: userID},
@@ -368,7 +368,7 @@ function updateRecordStatus(record_ID, record_startTime, customerID, customerNam
     return;
   }
   
-  startsec = record_startTime;
+  startsec = record_startTime + offset;
   
   if (selected_project != projectID)
     buzzer_preselect_project(projectID, projectName, customerID, customerName, false);
@@ -467,10 +467,12 @@ function buzzer_preselect_update_ui(selector,selectedID,updateRecording) {
 // ... so just THX! ;)
 
 function ticktac() {
+    // startsec is an absolute timestamp adjusted to local time on page load.
+    // total seconds = "getTime" local time - "startsec" from server adjusted to local time
+    var total_seconds = Math.floor((new Date()).getTime() / 1000) - startsec;
+
     // Split total seconds from start time to current time into
     // separate variables for viewing hours:minutes:seconds
-    var startsecoffset = startsec ? startsec : offset;
-    var total_seconds = Math.floor((new Date()).getTime() / 1000) - startsecoffset;
     var hours   = Math.floor(total_seconds / 3600);
     var minutes = Math.floor((total_seconds - hours * 3600) / 60);
     var seconds = Math.floor(total_seconds - hours * 3600 - minutes * 60);

--- a/templates/scripts/core/main.php
+++ b/templates/scripts/core/main.php
@@ -82,9 +82,9 @@
        
         var timeoutTicktack       = 0;
         
-        var startsec              = <?php echo $this->current_timer_start ?>;
         var now                   = <?php echo $this->current_time ?>;
         var offset                = Math.floor(((new Date()).getTime())/1000)-now;
+        var startsec              = <?php echo $this->current_timer_start ?> + offset;
         
 
         var default_title         = "<?php echo isset($this->kga['user']) ? $this->escape($this->kga['user']['name']) : $this->escape($this->kga['customer']['name'])?> - Kimai";


### PR DESCRIPTION
FIXES #507

Changes proposed in this pull request:
- Adjust offset for stopwatch (ticktac) near the buzzer
- "offset" is timediff between server and local, only set ones on page load, not changed later.
- On loading page the "offset" was calculated as difference between server and browser like
  `offset = browserTime - serverTime`
- "startsec" is start timstamp for stopwatch as browser time base

Reason for this pull request:
- After this modification the "startsec" contains the absolute time of start, adjusted to the browser base in all cases (start from buzzer, "start again" from time sheet, or start from reloading the page).
- To get the counted time for stopwatch, the function ticktac must simple differ "startsec" from current browser time.
- In old version: If server and local time differ _some minutes_, and you starts a stopwatch via "record again", then stopwatch shows these _some minutes_ after first seconds.

How to test:
1. Force a timediff between server and your local system. For example set your local time 1 hour in future of _same_ timezone. Set local time 14:00 CET, if the server time is 13:00 CET.
2. In the timesheet press "record again" from any line
3. After 1 or 2 seconds the stopwatch will display "01:00:01"

_This is a part of pull request #681_
