### PR TITLE
Admin refactor

### DIFF
--- a/extensions/ki_adminpanel/floaters.php
+++ b/extensions/ki_adminpanel/floaters.php
@@ -22,8 +22,6 @@ $isCoreProcessor = 0;
 $dir_templates = "templates";
 require '../../includes/kspi.php';
 
-$settings = parse_ini_file("config.ini");
-
 $view = new Kimai_View();
 $view->addBasePath(__DIR__ . '/templates/');
 
@@ -50,7 +48,7 @@ switch ($axAction) {
             $view->memberships[$groupId] = $database->user_get_membership_role($id, $groupId);
         }
 
-        $groups = $database->get_groups(get_cookie('adminPanel_extension_show_deleted_groups', 0));
+        $groups = $database->get_groups();
         if ($database->global_role_allows($kga['user']['globalRoleID'], 'core-group-otherGroup-view')) {
             $view->assign('groups', $groups);
         } else {

--- a/extensions/ki_adminpanel/functions.php
+++ b/extensions/ki_adminpanel/functions.php
@@ -17,14 +17,185 @@
  * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
  */
 
-function getEditUserList(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroups)
+/**
+ * @param Kimai_Database_Mysql $database
+ * @param array $kgaUser
+ * @param bool $viewOtherGroupsAllowed
+ * @return array
+ */
+function getGroupsData(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroupsAllowed)
+{
+    $groups = $database->get_groups();
+    $allowedGroups = $groups;
+    if (!$viewOtherGroupsAllowed) {
+        $allowedGroups = array_filter(
+            $groups,
+            function ($group) use ($kgaUser) {
+                return array_search($group['groupID'], $kgaUser['groups']) !== false;
+            }
+        );
+    }
+
+    return array(
+        'groups' => $allowedGroups
+    );
+}
+
+/**
+ * @param Kimai_Database_Mysql $database
+ * @param array $kgaUser
+ * @param bool $viewOtherGroupsAllowed
+ * @return array
+ */
+function getProjectsData(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroupsAllowed)
+{
+    if ($database->global_role_allows($kgaUser['globalRoleID'], 'core-project-otherGroup-view')) {
+        $projects = $database->get_projects();
+    } else {
+        $projects = $database->get_projects($kgaUser['groups']);
+    }
+
+    $result = array();
+
+    if ($projects !== null && is_array($projects)) {
+        foreach ($projects as $row => $project) {
+            $groupNames = array();
+            foreach ($database->project_get_groupIDs($project['projectID']) as $groupID) {
+                if (!$viewOtherGroupsAllowed && array_search($groupID, $kgaUser['groups']) === false) {
+                    continue;
+                }
+                $data = $database->group_get_data($groupID);
+                $groupNames[] = $data['name'];
+            }
+            $projects[$row]['groups'] = implode(", ", $groupNames);
+        }
+        $result['projects'] = $projects;
+    }
+
+    return $result;
+}
+
+/**
+ * @param Kimai_Database_Mysql $database
+ * @param array $kgaUser
+ * @param bool $viewOtherGroupsAllowed
+ * @return array
+ */
+function getCustomersData(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroupsAllowed)
+{
+    if ($database->global_role_allows($kgaUser['globalRoleID'], 'core-customer-otherGroup-view')) {
+        $customers = $database->get_customers();
+    } else {
+        $customers = $database->get_customers($kgaUser['groups']);
+    }
+
+    foreach ($customers as $row => $data) {
+        $groupNames = array();
+        $groups = $database->customer_get_groupIDs($data['customerID']);
+        if ($groups !== false) {
+            foreach ($groups as $groupID) {
+                if (!$viewOtherGroupsAllowed && array_search($groupID, $kgaUser['groups']) === false) {
+                    continue;
+                }
+                $data = $database->group_get_data($groupID);
+                $groupNames[] = $data['name'];
+            }
+            $customers[$row]['groups'] = implode(", ", $groupNames);
+        }
+    }
+
+    return array(
+        'customers' => $customers
+    );
+}
+
+/**
+ * @param Kimai_Database_Mysql $database
+ * @param array $kgaUser
+ * @param bool $viewOtherGroupsAllowed
+ * @return array
+ */
+function getUsersData(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroupsAllowed)
+{
+    $result = array(
+        'showDeletedUsers' => get_cookie('adminPanel_extension_show_deleted_users', 0),
+        'curr_user' => $kgaUser['name'],
+        'users' => getEditUserList($database, $kgaUser, $viewOtherGroupsAllowed)
+    );
+    return $result;
+}
+
+/**
+ * @param Kimai_Database_Mysql $database
+ * @param array $kgaUser
+ * @param bool $viewOtherGroupsAllowed
+ * @return array
+ * @throws Zend_View_Exception
+ */
+function getActivitiesData(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroupsAllowed)
+{
+    $groups = null;
+    if (!$database->global_role_allows($kgaUser['globalRoleID'], 'core-activity-otherGroup-view')) {
+        $groups = $kgaUser['groups'];
+    }
+
+    $activity_filter = isset($_REQUEST['activity_filter']) ? intval($_REQUEST['activity_filter']) : -2;
+
+    switch ($activity_filter) {
+        case -2:
+            // -2 is not a valid project id this will give us all unassigned activities.
+            $activities = $database->get_activities_by_project(-2, $groups);
+            break;
+        case -1:
+            $activities = $database->get_activities($groups);
+            break;
+        default:
+            $activities = $database->get_activities_by_project($activity_filter, $groups);
+    }
+
+    foreach ($activities as $row => $activity) {
+        $groupNames = array();
+        foreach ($database->activity_get_groups($activity['activityID']) as $groupID) {
+            if (!$viewOtherGroupsAllowed && array_search($groupID, $kgaUser['groups']) === false) {
+                continue;
+            }
+            $data = $database->group_get_data($groupID);
+            $groupNames[] = $data['name'];
+        }
+        $activities[$row]['groups'] = implode(", ", $groupNames);
+
+        $activities[$row]['projects'] = $database->activity_get_projects($activity['activityID']);
+    }
+
+    $result = array();
+
+    if (count($activities) > 0) {
+        $result['activities'] = $activities;
+    } else {
+        $result['activities'] = array();
+    }
+
+    $result['projects'] = $database->get_projects($groups);
+    $result['selected_activity_filter']= $activity_filter;
+
+    return $result;
+}
+
+/**
+ * @param Kimai_Database_Mysql $database
+ * @param array $kgaUser
+ * @param bool $viewOtherGroupsAllowed
+ * @return array
+ */
+function getEditUserList(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGroupsAllowed)
 {
     $users = array();
+    $showDeletedUsers = get_cookie('adminPanel_extension_show_deleted_users', 0);
 
     if ($database->global_role_allows($kgaUser['globalRoleID'], 'core-user-otherGroup-view')) {
-        $dbUsers = $database->get_users(get_cookie('adminPanel_extension_show_deleted_users', 0));
+        $dbUsers = $database->get_users($showDeletedUsers);
     } else {
-        $dbUsers = $database->get_users(get_cookie('adminPanel_extension_show_deleted_users', 0), $kgaUser['groups']);
+        $dbUsers = $database->get_users($showDeletedUsers, $kgaUser['groups']);
     }
 
     $roles = $database->global_roles();
@@ -45,7 +216,7 @@ function getEditUserList(Kimai_Database_Mysql $database, $kgaUser, $viewOtherGro
         $groups = $database->getGroupMemberships($user['userID']);
         if (is_array($groups)) {
             foreach ($groups as $group) {
-                if (!$viewOtherGroups && array_search($group, $kgaUser['groups']) === false) {
+                if (!$viewOtherGroupsAllowed && array_search($group, $kgaUser['groups']) === false) {
                     continue;
                 }
                 $groupData = $database->group_get_data($group);

--- a/extensions/ki_adminpanel/js/ap_func.js
+++ b/extensions/ki_adminpanel/js/ap_func.js
@@ -322,7 +322,6 @@ function adminPanel_extension_refreshSubtab(tab) {
             case "users":  	target = "#adminPanel_extension_s1"; break
             case "groups":  	target = "#adminPanel_extension_s2"; break
             case "status":  target = "#adminPanel_extension_s3"; break
-            case "advanced":  	target = "#adminPanel_extension_s4"; break
             case "database":   	target = "#adminPanel_extension_s5"; break
             case "customers":  	target = "#adminPanel_extension_s6"; break
             case "projects": 	target = "#adminPanel_extension_s7"; break

--- a/extensions/ki_adminpanel/processor.php
+++ b/extensions/ki_adminpanel/processor.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of
  * Kimai - Open Source Time Tracking // http://www.kimai.org
- * (c) 2006-2009 Kimai-Development-Team
+ * (c) Kimai-Development-Team since 2006
  *
  * Kimai is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -116,54 +116,29 @@ switch ($axAction)
         break;
 
     case "refreshSubtab" :
-        // builds either user/group/advanced/DB subtab
-        $view->assign('curr_user', $kga['user']['name']);
-        $groups = $database->get_groups(get_cookie('adminPanel_extension_show_deleted_groups', 0));
         $viewOtherGroupsAllowed = $database->global_role_allows($kga['user']['globalRoleID'], 'core-group-otherGroup-view');
-        if ($viewOtherGroupsAllowed) {
-            $view->assign('groups', $groups);
-        } else {
-            $view->assign('groups', array_filter(
-                $groups,
-                function ($group) {
-                    global $kga;
-                    return array_search($group['groupID'], $kga['user']['groups']) !== false;
-                }
-            ));
-        }
-
-        $arr_status = $database->get_statuses();
-        $view->assign('users', getEditUserList($database, $kga['user'], $viewOtherGroupsAllowed));
-        $view->assign('arr_status', $arr_status);
-        $view->assign('showDeletedGroups', get_cookie('adminPanel_extension_show_deleted_groups', 0));
-        $view->assign('showDeletedUsers', get_cookie('adminPanel_extension_show_deleted_users', 0));
 
         switch ($axValue)
         {
-            case "users" :
+            case "users":
+                $userData = getUsersData($database, $kga['user'], $viewOtherGroupsAllowed);
+                foreach($userData as $key => $value) {
+                    $view->assign($key, $value);
+                }
                 echo $view->render('users.php');
                 break;
 
-            case "groups" :
+            case "groups":
+                $groupsData = getGroupsData($database, $kga['user'], $viewOtherGroupsAllowed);
+                foreach($groupsData as $key => $value) {
+                    $view->assign($key, $value);
+                }
                 echo $view->render('groups.php');
                 break;
 
-            case "status" :
+            case "status":
+                $view->assign('statuses', $database->get_statuses());
                 echo $view->render('status.php');
-                break;
-
-            case "advanced" :
-                if ($kga['conf']['editLimit'] != '-') {
-                    $view->assign('editLimitEnabled', true);
-                    $editLimit = $kga['conf']['editLimit'] / (60 * 60); // convert to hours
-                    $view->assign('editLimitDays', (int)($editLimit / 24));
-                    $view->assign('editLimitHours', (int)($editLimit % 24));
-                } else {
-                    $view->assign('editLimitEnabled', false);
-                    $view->assign('editLimitDays', '');
-                    $view->assign('editLimitHours', '');
-                }
-                echo $view->render('advanced.php');
                 break;
 
             case "database" :
@@ -171,105 +146,26 @@ switch ($axAction)
                 break;
 
             case "customers" :
-                $viewOtherGroupsAllowed = $database->global_role_allows($kga['user']['globalRoleID'], 'core-group-otherGroup-view');
-                if ($database->global_role_allows($kga['user']['globalRoleID'], 'core-customer-otherGroup-view')) {
-                    $customers = $database->get_customers();
-                } else {
-                    $customers = $database->get_customers($kga['user']['groups']);
-                }
-
-                foreach ($customers as $row => $data) {
-                    $groupNames = array();
-                    $groups = $database->customer_get_groupIDs($data['customerID']);
-                    if ($groups !== false) {
-                        foreach ($groups as $groupID) {
-                            if (!$viewOtherGroupsAllowed && array_search($groupID, $kga['user']['groups']) === false) {
-                                continue;
-                            }
-                            $data = $database->group_get_data($groupID);
-                            $groupNames[] = $data['name'];
-                        }
-                        $customers[$row]['groups'] = implode(", ", $groupNames);
-                    }
-                }
-                if (count($customers) > 0) {
-                    $view->assign('customers', $customers);
-                } else {
-                    $view->assign('customers', '0');
+                $customersData = getCustomersData($database, $kga['user'], $viewOtherGroupsAllowed);
+                foreach ($customersData as $key => $value) {
+                    $view->assign($key, $value);
                 }
                 echo $view->render('customers.php');
                 break;
 
             case "projects" :
-                $viewOtherGroupsAllowed = $database->global_role_allows($kga['user']['globalRoleID'], 'core-group-otherGroup-view');
-                if ($database->global_role_allows($kga['user']['globalRoleID'], 'core-project-otherGroup-view')) {
-                    $projects = $database->get_projects();
-                } else {
-                    $projects = $database->get_projects($kga['user']['groups']);
+                $projectsData = getProjectsData($database, $kga['user'], $viewOtherGroupsAllowed);
+                foreach ($projectsData as $key => $value) {
+                    $view->assign($key, $value);
                 }
-
-                if ($projects !== null && is_array($projects)) {
-                    foreach ($projects as $row => $project) {
-                        $groupNames = array();
-                        foreach ($database->project_get_groupIDs($project['projectID']) as $groupID) {
-                            if (!$viewOtherGroupsAllowed && array_search($groupID, $kga['user']['groups']) === false) {
-                                continue;
-                            }
-                            $data = $database->group_get_data($groupID);
-                            $groupNames[] = $data['name'];
-                        }
-                        $projects[$row]['groups'] = implode(", ", $groupNames);
-                    }
-                    $view->assign('projects', $projects);
-                }
-
                 echo $view->render('projects.php');
                 break;
 
             case "activities" :
-                $viewOtherGroupsAllowed = $database->global_role_allows($kga['user']['globalRoleID'], 'core-group-otherGroup-view');
-                $groups = null;
-                if (!$database->global_role_allows($kga['user']['globalRoleID'], 'core-activity-otherGroup-view')) {
-                    $groups = $kga['user']['groups'];
+                $activitiesData = getActivitiesData($database, $kga['user'], $viewOtherGroupsAllowed);
+                foreach($activitiesData as $key => $data) {
+                    $view->assign($key, $data);
                 }
-
-                $activity_filter = isset($_REQUEST['activity_filter']) ? intval($_REQUEST['activity_filter']) : -2;
-
-                switch ($activity_filter) {
-                    case -2:
-                        // -2 is to get unassigned activities. As -2 is never
-                        // an id of a project this will give us all unassigned
-                        // activities.
-                        $activities = $database->get_activities_by_project(-2, $groups);
-                        break;
-                    case -1:
-                        $activities = $database->get_activities($groups);
-                        break;
-                    default:
-                        $activities = $database->get_activities_by_project($activity_filter, $groups);
-                }
-
-                foreach ($activities as $row => $activity) {
-                    $groupNames = array();
-                    foreach ($database->activity_get_groups($activity['activityID']) as $groupID) {
-                        if (!$viewOtherGroupsAllowed && array_search($groupID, $kga['user']['groups']) === false) {
-                            continue;
-                        }
-                        $data = $database->group_get_data($groupID);
-                        $groupNames[] = $data['name'];
-                    }
-                    $activities[$row]['groups'] = implode(", ", $groupNames);
-                }
-
-                if (count($activities) > 0) {
-                    $view->assign('activities', $activities);
-                } else {
-                    $view->assign('activities', '0');
-                }
-
-                $projects = $database->get_projects($groups);
-                $view->assign('projects', $projects);
-                $view->assign('selected_activity_filter', isset($_REQUEST['activity_filter']) ? $_REQUEST['activity_filter'] : -2);
                 echo $view->render('activities.php');
                 break;
 

--- a/extensions/ki_adminpanel/templates/scripts/customers.php
+++ b/extensions/ki_adminpanel/templates/scripts/customers.php
@@ -3,10 +3,10 @@
 <table>
 	<thead>
 		<tr class="headerrow">
-			<th><?php echo $this->kga['lang']['options']?></th>
-			<th><?php echo $this->kga['lang']['customer']?></th>
+			<th width="80px"><?php echo $this->kga['lang']['options']?></th>
+			<th width="25%"><?php echo $this->kga['lang']['customer']?></th>
 			<th><?php echo $this->kga['lang']['contactPerson']?></th>
-			<th><?php echo $this->kga['lang']['groups']?></th>
+			<th width="25%"><?php echo $this->kga['lang']['groups']?></th>
 		</tr>
 	</thead>
 	<tbody>

--- a/extensions/ki_adminpanel/templates/scripts/globalRoles.php
+++ b/extensions/ki_adminpanel/templates/scripts/globalRoles.php
@@ -6,8 +6,8 @@
 <table>
     <thead>
     <tr class='headerrow'>
-        <th><?php echo $this->kga['lang']['options'] ?></th>
-        <th><?php echo $this->kga['lang']['globalRole'] ?></th>
+        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
+        <th width="25%"><?php echo $this->kga['lang']['globalRole'] ?></th>
         <th><?php echo $this->kga['lang']['users'] ?></th>
     </tr>
     </thead>

--- a/extensions/ki_adminpanel/templates/scripts/groups.php
+++ b/extensions/ki_adminpanel/templates/scripts/groups.php
@@ -6,8 +6,8 @@
 <table>
     <thead>
     <tr class='headerrow'>
-        <th><?php echo $this->kga['lang']['options'] ?></th>
-        <th><?php echo $this->kga['lang']['group'] ?></th>
+        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
+        <th width="25%"><?php echo $this->kga['lang']['group'] ?></th>
         <th><?php echo $this->kga['lang']['members'] ?></th>
     </tr>
     </thead>

--- a/extensions/ki_adminpanel/templates/scripts/main.php
+++ b/extensions/ki_adminpanel/templates/scripts/main.php
@@ -1,130 +1,47 @@
 <div id="adminPanel_extension_panel">
-    <!-- edit customers -->
-    <div id="adminPanel_extension_sub6">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(6)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['customers'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s6" class="adminPanel_extension_subtab adminPanel_extension_subject">
-            <?php echo $this->customer_display ?>
-        </div>
-    </div>
-    <!-- edit projects -->
-    <div id="adminPanel_extension_sub7">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(7)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['projects'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s7" class="adminPanel_extension_subtab adminPanel_extension_subject">
-            <?php echo $this->project_display ?>
-        </div>
-    </div>
-    <!-- edit activities -->
-    <div id="adminPanel_extension_sub8">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(8)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['activities'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s8" class="adminPanel_extension_subtab adminPanel_extension_subject">
-            <?php echo $this->activity_display ?>
-        </div>
-    </div>
-    <!-- edit users -->
-    <div id="adminPanel_extension_sub1">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(1)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['users'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s1" class="adminPanel_extension_subtab">
-            <?php echo $this->admin['users']; ?>
-        </div>
-    </div>
-    <!-- edit groups -->
-    <div id="adminPanel_extension_sub2">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(2)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['groups'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s2" class="adminPanel_extension_subtab">
-            <?php echo $this->admin['groups'] ?>
-        </div>
-    </div>
-    <!-- edit global roles -->
-    <div id="adminPanel_extension_sub9">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(9)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['globalRoles'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s9" class="adminPanel_extension_subtab">
-            <?php echo $this->globalRoles_display ?>
-        </div>
-    </div>
-    <!-- edit membership roles -->
-    <div id="adminPanel_extension_sub10">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(10)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['membershipRoles'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s10" class="adminPanel_extension_subtab">
-            <?php echo $this->membershipRoles_display ?>
-        </div>
-    </div>
-    <!-- edit status -->
-    <div id="adminPanel_extension_sub3">
-        <div class="adminPanel_extension_panel_header">
-            <a onclick="adminPanel_extension_subtab_expand(3)">
-                <span class="adminPanel_extension_accordeon_triangle"></span>
-                <?php echo $this->kga['lang']['status'] ?>
-            </a>
-        </div>
-        <div id="adminPanel_extension_s3" class="adminPanel_extension_subtab">
-            <?php echo $this->admin['status'] ?>
-        </div>
-    </div>
-    <?php if ($this->showAdvancedTab): ?>
-        <!-- advanced -->
-        <div id="adminPanel_extension_sub4">
-            <div class="adminPanel_extension_panel_header">
-                <a onclick="adminPanel_extension_subtab_expand(4)">
-                    <span class="adminPanel_extension_accordeon_triangle"></span>
-                    <?php echo $this->kga['lang']['advanced'] ?>
-                </a>
-            </div>
-            <div id="adminPanel_extension_s4" class="adminPanel_extension_subtab">
-                <?php echo $this->admin['advanced'] ?>
-            </div>
-        </div>
+
+    <?php if (isset($this->tab_customer)): ?>
+        <?php echo $this->adminScreen()->accordion(6, $this->translate('customers'), $this->tab_customer); ?>
     <?php endif; ?>
 
-    <?php if (isset($this->admin['database'])): ?>
-        <!-- DB -->
-        <div id="adminPanel_extension_sub5">
-            <div class="adminPanel_extension_panel_header">
-                <a onclick="adminPanel_extension_subtab_expand(5)">
-                    <span class="adminPanel_extension_accordeon_triangle"></span>
-                    <?php echo $this->kga['lang']['database'] ?>
-                </a>
-            </div>
-            <div id="adminPanel_extension_s5" class="adminPanel_extension_subtab">
-                <?php echo $this->admin['database'] ?>
-            </div>
-        </div>
+    <?php if (isset($this->tab_project)): ?>
+        <?php echo $this->adminScreen()->accordion(7, $this->translate('projects'), $this->tab_project); ?>
     <?php endif; ?>
+
+    <?php if (isset($this->tab_activity)): ?>
+        <?php echo $this->adminScreen()->accordion(8, $this->translate('activities'), $this->tab_activity); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_users)): ?>
+        <?php echo $this->adminScreen()->accordion(1, $this->translate('users'), $this->tab_users); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_groups)): ?>
+        <?php echo $this->adminScreen()->accordion(2, $this->translate('groups'), $this->tab_groups); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_globalrole)): ?>
+        <?php echo $this->adminScreen()->accordion(9, $this->translate('globalRoles'), $this->tab_globalrole); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_membershiprole)): ?>
+        <?php echo $this->adminScreen()->accordion(10, $this->translate('membershipRoles'), $this->tab_membershiprole); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_status)): ?>
+        <?php echo $this->adminScreen()->accordion(3, $this->translate('status'), $this->tab_status); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_advanced)): ?>
+        <?php echo $this->adminScreen()->accordion(4, $this->translate('advanced'), $this->tab_advanced); ?>
+    <?php endif; ?>
+
+    <?php if (isset($this->tab_database)): ?>
+        <?php echo $this->adminScreen()->accordion(5, $this->translate('database'), $this->tab_database); ?>
+    <?php endif; ?>
+
 </div>
+
 <script type="text/javascript">
     $(document).ready(function () {
         adminPanel_extension_onload();

--- a/extensions/ki_adminpanel/templates/scripts/membershipRoles.php
+++ b/extensions/ki_adminpanel/templates/scripts/membershipRoles.php
@@ -6,8 +6,8 @@
 <table>
     <thead>
     <tr class='headerrow'>
-        <th><?php echo $this->kga['lang']['options'] ?></th>
-        <th><?php echo $this->kga['lang']['membershipRole'] ?></th>
+        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
+        <th width="25%"><?php echo $this->kga['lang']['membershipRole'] ?></th>
         <th><?php echo $this->kga['lang']['users'] ?></th>
     </tr>
     </thead>

--- a/extensions/ki_adminpanel/templates/scripts/projects.php
+++ b/extensions/ki_adminpanel/templates/scripts/projects.php
@@ -3,15 +3,15 @@
 <table>
 <thead>
 	<tr class="headerrow">
-		<th><?php echo $this->kga['lang']['options']?></th>
+		<th width="80px"><?php echo $this->kga['lang']['options']?></th>
 		<?php if ($this->kga['conf']['flip_project_display']): ?>
-		<th><?php echo $this->kga['lang']['customer']?></th>
-		<th><?php echo $this->kga['lang']['project']?></th>
+			<th width="25%"><?php echo $this->kga['lang']['customer']?></th>
+			<th><?php echo $this->kga['lang']['project']?></th>
 		<?php else: ?>
-		<th><?php echo $this->kga['lang']['project']?></th>
-		<th><?php echo $this->kga['lang']['customer']?></th>
+			<th width="25%"><?php echo $this->kga['lang']['project']?></th>
+			<th><?php echo $this->kga['lang']['customer']?></th>
 		<?php endif; ?>
-		<th><?php echo $this->kga['lang']['groups']?></th>
+		<th width="25%"><?php echo $this->kga['lang']['groups']?></th>
 	</tr>
 </thead>
 <tbody>
@@ -42,7 +42,7 @@
 				</td>
 				<?php if ($this->kga['conf']['flip_project_display']): ?>
 					<td class="customer <?php if ($isHidden) { echo 'hidden'; } ?>">
-						<?php echo $this->escape($this->truncate($row['customerName'], 30, '...'))?>
+						<?php echo $this->escape($this->ellipsis($row['customerName'], 30))?>
 					</td>
 					<td class="projects <?php if ($isHidden) { echo 'hidden'; } ?>">
 						<?php echo $this->escape($row['name']) ?>
@@ -52,7 +52,7 @@
 						<?php echo $this->escape($row['name']) ?>
 					</td>
 					<td class="customer <?php if ($isHidden) { echo 'hidden'; } ?>">
-						<?php echo $this->escape($this->truncate($row['customerName'], 30, '...'))?>
+						<?php echo $this->escape($this->ellipsis($row['customerName'], 30))?>
 					</td>
 				<?php endif; ?>
 				<td class="<?php if ($isHidden) { echo 'hidden'; } ?>">

--- a/extensions/ki_adminpanel/templates/scripts/status.php
+++ b/extensions/ki_adminpanel/templates/scripts/status.php
@@ -6,14 +6,14 @@
 <table>
     <thead>
     <tr class='headerrow'>
-        <th><?php echo $this->kga['lang']['options'] ?></th>
-        <th><?php echo $this->kga['lang']['status'] ?></th>
+        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
+        <th width="25%"><?php echo $this->kga['lang']['status'] ?></th>
         <th><?php echo $this->kga['lang']['default'] ?></th>
     </tr>
     </thead>
     <tbody>
     <?php
-    if (!isset($this->arr_status) || $this->arr_status == '0' || count($this->arr_status) == 0) {
+    if (!isset($this->statuses) || $this->statuses == '0' || count($this->statuses) == 0) {
         ?>
         <tr>
             <td nowrap colspan='3'>
@@ -22,7 +22,7 @@
         </tr>
         <?php
     } else {
-        foreach ($this->arr_status as $statusarray) {
+        foreach ($this->statuses as $statusarray) {
             ?>
             <tr class='<?php echo $this->cycle(array("odd", "even"))->next() ?>'>
                 <td class="option">

--- a/extensions/ki_adminpanel/templates/scripts/users.php
+++ b/extensions/ki_adminpanel/templates/scripts/users.php
@@ -11,11 +11,11 @@
 <table>
     <thead>
     <tr>
-        <th><?php echo $this->kga['lang']['options'] ?></th>
-        <th><?php echo $this->kga['lang']['username'] ?></th>
+        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
+        <th width="25%"><?php echo $this->kga['lang']['username'] ?></th>
         <th><?php echo $this->kga['lang']['status'] ?></th>
         <th><?php echo $this->kga['lang']['globalRole'] ?></th>
-        <th><?php echo $this->kga['lang']['groups'] ?></th>
+        <th width="25%"><?php echo $this->kga['lang']['groups']?></th>
     </tr>
     </thead>
     <tbody>

--- a/libraries/Kimai/View.php
+++ b/libraries/Kimai/View.php
@@ -30,6 +30,7 @@ class Kimai_View extends Zend_View
 
         $this->setBasePath(APPLICATION_PATH . '/templates/');
         $this->addHelperPath(APPLICATION_PATH . '/templates/helpers/', 'Zend_View_Helper');
+        $this->addHelperPath(APPLICATION_PATH . '/libraries/Kimai/View/Helper/', 'Kimai_View_Helper');
 
         parent::init();
         $this->kga = $kga;

--- a/libraries/Kimai/View/Helper/AdminScreen.php
+++ b/libraries/Kimai/View/Helper/AdminScreen.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This file is part of
+ * Kimai - Open Source Time Tracking // http://www.kimai.org
+ * (c) Kimai-Development-Team since 2006
+ *
+ * Kimai is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; Version 3, 29 June 2007
+ *
+ * Kimai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * A view helper to render HTML components for the admin section.
+ */
+class Kimai_View_Helper_AdminScreen extends Zend_View_Helper_Abstract
+{
+
+    /**
+     * @return $this
+     */
+    public function adminScreen()
+    {
+        return $this;
+    }
+
+    /**
+     * Returns the HTML to render an accordion.
+     *
+     * @param $id
+     * @param $title
+     * @param $content
+     * @return string
+     */
+    public function accordion($id, $title, $content)
+    {
+        return $this->accordionHeader($id, $title) .
+            $this->accordionContent($content) .
+            $this->accordionFooter($id);
+    }
+
+    protected function accordionHeader($id, $title)
+    {
+        return '
+            <div id="adminPanel_extension_sub'.$id.'">
+                <div class="adminPanel_extension_panel_header">
+                    <a onClick="adminPanel_extension_subtab_expand('.$id.')">
+                        <span class="adminPanel_extension_accordeon_triangle"></span>
+                        '.$this->accordionTitle($title).'
+                    </a>
+                </div>
+                <div id="adminPanel_extension_s'.$id.'" class="adminPanel_extension_subtab">
+        ';
+    }
+
+    protected function accordionTitle($title)
+    {
+        return $title;
+    }
+
+    protected function accordionContent($content)
+    {
+        return $content;
+    }
+
+    protected function accordionFooter($id)
+    {
+        return '
+                </div>
+            </div>
+        ';
+    }
+}

--- a/tests/library/Kimai/View/Helper/AdminScreenTest.php
+++ b/tests/library/Kimai/View/Helper/AdminScreenTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file is part of
+ * Kimai - Open Source Time Tracking // http://www.kimai.org
+ * (c) Kimai-Development-Team since 2006
+ *
+ * Kimai is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; Version 3, 29 June 2007
+ *
+ * Kimai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace KimaiTest\View\Helper;
+
+use KimaiTest\TestCase;
+use Kimai_View_Helper_AdminScreen;
+
+/**
+ * @coversDefaultClass Kimai_View_Helper_AdminScreen
+ */
+class AdminScreenTest extends TestCase
+{
+
+    /**
+     * @covers ::adminScreen
+     */
+    public function testAdminScreenReturnsSelf()
+    {
+        $helper = new Kimai_View_Helper_AdminScreen();
+        $this->assertInstanceOf('Kimai_View_Helper_AdminScreen', $helper->adminScreen());
+    }
+
+    /**
+     * @covers ::accordion
+     * @covers ::accordionHeader
+     * @covers ::accordionContent
+     * @covers ::accordionFooter
+     * @covers ::accordionTitle
+     */
+    public function testAccordionHtmlContainsElements()
+    {
+        $id = 4711;
+        $title = 'FooBar';
+        $content = '<h1>Some HTML content</h1>';
+
+        $helper = new Kimai_View_Helper_AdminScreen();
+        $html = $helper->accordion($id, $title, $content);
+
+        $this->assertGreaterThan(0, stripos($html, $id));
+        $this->assertGreaterThan(0, stripos($html, $title));
+        $this->assertGreaterThan(0, stripos($html, $content));
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- move re-occuring HTML structures to ViewHelpers to allow overwriting by skins (in a later step)
- moved code (from init.php, processor.php and floaters.php) to functions.php in order to avoid the currently existing code duplications (and all related problems like future updates or bugs fixed in one place only)
- use the same widths for all admin tables columns to unifiy the UI
- improvement: show customer name as hidden to indicate that the project is implicit hidden as well
