### PR TITLE
ticktac: hour,min,sec, and more local variables

### DIFF
--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -276,7 +276,7 @@ function ts_ext_recordAgain(project,activity,id) {
     }
 
     $('#timeSheetEntry'+id+'>td>a.recordAgain>img').attr("src","../skins/"+skin+"/grfx/loading13.gif");
-    var now = Math.floor(((new Date()).getTime())/1000);
+    var now = Math.floor(((new Date()).getTime()) / 1000);
     offset = now;
     startsec = 0;
     show_stopwatch();

--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -406,15 +406,15 @@ function pasteNow(value) {
 
     var now = new Date();
 
-    H = now.getHours();
-    i = now.getMinutes();
-    s = now.getSeconds();
+    var H = now.getHours();
+    var i = now.getMinutes();
+    var s = now.getSeconds();
 
     if (H<10) H = "0"+H;
     if (i<10) i = "0"+i;
     if (s<10) s = "0"+s;
 
-    time  = H + ":" + i + ":" + s;
+    var time  = H + ":" + i + ":" + s;
 
     $("#end_time").val(time);
     $('#end_time').trigger('change');

--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -276,7 +276,6 @@ function ts_ext_recordAgain(project,activity,id) {
     }
 
     $('#timeSheetEntry'+id+'>td>a.recordAgain>img').attr("src","../skins/"+skin+"/grfx/loading13.gif");
-    hour=0;min=0;sec=0;
     now = Math.floor(((new Date()).getTime())/1000);
     offset = now;
     startsec = 0;

--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -276,7 +276,7 @@ function ts_ext_recordAgain(project,activity,id) {
     }
 
     $('#timeSheetEntry'+id+'>td>a.recordAgain>img').attr("src","../skins/"+skin+"/grfx/loading13.gif");
-    now = Math.floor(((new Date()).getTime())/1000);
+    var now = Math.floor(((new Date()).getTime())/1000);
     offset = now;
     startsec = 0;
     show_stopwatch();
@@ -404,7 +404,7 @@ function getBestRates() {
 //
 function pasteNow(value) {
 
-    now = new Date();
+    var now = new Date();
 
     H = now.getHours();
     i = now.getMinutes();

--- a/js/main.js
+++ b/js/main.js
@@ -335,7 +335,7 @@ function updateTimeframeWarning() {
 // starts a new recording when the start-buzzer is hidden
 //
 function startRecord(projectID,activityID,userID) {
-    var now = Math.floor(((new Date()).getTime())/1000);
+    var now = Math.floor(((new Date()).getTime()) / 1000);
     offset = 0;
     startsec = now;
     show_stopwatch();
@@ -481,16 +481,23 @@ function ticktac() {
     // Split total seconds from start time to current time into
     // separate variables for viewing hours:minutes:seconds
     var startsecoffset = startsec ? startsec : offset;
-    var total_seconds = Math.floor((new Date()).getTime()/1000)-startsecoffset;
+    var total_seconds = Math.floor((new Date()).getTime() / 1000) - startsecoffset;
     var hours   = Math.floor(total_seconds / 3600);
-    var minutes = Math.floor((total_seconds-hours*3600) / 60);
-    var seconds = Math.floor(total_seconds-hours*3600-minutes*60);
-    
-    if (seconds==60) { seconds=0; minutes++; }
-    if (minutes > 59) { minutes = 0; hours++; }
-    $("#s").html(((seconds<10)?"0":"")+seconds);
-    $("#m").html(((minutes<10)?"0":"")+minutes);
-    $("#h").html(((hours<10)?"0":"")+hours);
+    var minutes = Math.floor((total_seconds - hours * 3600) / 60);
+    var seconds = Math.floor(total_seconds - hours * 3600 - minutes * 60);
+
+    if (seconds == 60) {
+        seconds = 0;
+        minutes++;
+    }
+    if (minutes > 59) {
+        minutes = 0;
+        hours++;
+    }
+
+    $("#s").html(((seconds < 10) ? "0" : "") + seconds);
+    $("#m").html(((minutes < 10) ? "0" : "") + minutes);
+    $("#h").html(((hours   < 10) ? "0" : "") + hours);
 
     var htmp = $("#h").html();
     var mtmp = $("#m").html();

--- a/js/main.js
+++ b/js/main.js
@@ -478,17 +478,19 @@ function buzzer_preselect_update_ui(selector,selectedID,updateRecording) {
 // ... so just THX! ;)
 
 function ticktac() {
+    // Split total seconds from start time to current time into
+    // separate variables for viewing hours:minutes:seconds
     var startsecoffset = startsec ? startsec : offset;
-    var sek   = Math.floor((new Date()).getTime()/1000)-startsecoffset;
-    var hour  = Math.floor(sek / 3600);
-    var min   = Math.floor((sek-hour*3600) / 60);
-    var sec   = Math.floor(sek-hour*3600-min*60);
+    var total_seconds = Math.floor((new Date()).getTime()/1000)-startsecoffset;
+    var hours   = Math.floor(total_seconds / 3600);
+    var minutes = Math.floor((total_seconds-hours*3600) / 60);
+    var seconds = Math.floor(total_seconds-hours*3600-minutes*60);
     
-    if (sec==60) { sec=0; min++; }
-    if (min > 59) { min = 0; hour++; }
-    $("#s").html(((sec<10)?"0":"")+sec);
-    $("#m").html(((min<10)?"0":"")+min);
-    $("#h").html(((hour<10)?"0":"")+hour);
+    if (seconds==60) { seconds=0; minutes++; }
+    if (minutes > 59) { minutes = 0; hours++; }
+    $("#s").html(((seconds<10)?"0":"")+seconds);
+    $("#m").html(((minutes<10)?"0":"")+minutes);
+    $("#h").html(((hours<10)?"0":"")+hours);
 
     var htmp = $("#h").html();
     var mtmp = $("#m").html();

--- a/js/main.js
+++ b/js/main.js
@@ -335,7 +335,6 @@ function updateTimeframeWarning() {
 // starts a new recording when the start-buzzer is hidden
 //
 function startRecord(projectID,activityID,userID) {
-    hour=0;min=0;sec=0;
     now = Math.floor(((new Date()).getTime())/1000);
     offset = 0;
     startsec = now;
@@ -479,11 +478,11 @@ function buzzer_preselect_update_ui(selector,selectedID,updateRecording) {
 // ... so just THX! ;)
 
 function ticktac() {
-    startsecoffset = startsec ? startsec : offset;
-    sek   = Math.floor((new Date()).getTime()/1000)-startsecoffset;
-    hour  = Math.floor(sek / 3600);
-    min   = Math.floor((sek-hour*3600) / 60);
-    sec   = Math.floor(sek-hour*3600-min*60);
+    var startsecoffset = startsec ? startsec : offset;
+    var sek   = Math.floor((new Date()).getTime()/1000)-startsecoffset;
+    var hour  = Math.floor(sek / 3600);
+    var min   = Math.floor((sek-hour*3600) / 60);
+    var sec   = Math.floor(sek-hour*3600-min*60);
     
     if (sec==60) { sec=0; min++; }
     if (min > 59) { min = 0; hour++; }
@@ -491,10 +490,10 @@ function ticktac() {
     $("#m").html(((min<10)?"0":"")+min);
     $("#h").html(((hour<10)?"0":"")+hour);
 
-    htmp = $("#h").html();
-    mtmp = $("#m").html();
-    stmp = $("#s").html();
-    titleclock = htmp + ":" + mtmp  + ":" + stmp;
+    var htmp = $("#h").html();
+    var mtmp = $("#m").html();
+    var stmp = $("#s").html();
+    var titleclock = htmp + ":" + mtmp  + ":" + stmp;
     document.title = titleclock;
     timeoutTicktack = setTimeout("ticktac()", 1000);
 }

--- a/js/main.js
+++ b/js/main.js
@@ -335,7 +335,7 @@ function updateTimeframeWarning() {
 // starts a new recording when the start-buzzer is hidden
 //
 function startRecord(projectID,activityID,userID) {
-    now = Math.floor(((new Date()).getTime())/1000);
+    var now = Math.floor(((new Date()).getTime())/1000);
     offset = 0;
     startsec = now;
     show_stopwatch();

--- a/templates/scripts/core/main.php
+++ b/templates/scripts/core/main.php
@@ -82,9 +82,6 @@
        
         var timeoutTicktack       = 0;
         
-        var hour                  = <?php echo $this->current_timer_hour ?>;
-        var min                   = <?php echo $this->current_timer_min ?>;
-        var sec                   = <?php echo $this->current_timer_sec ?>;
         var startsec              = <?php echo $this->current_timer_start ?>;
         var now                   = <?php echo $this->current_time ?>;
         var offset                = Math.floor(((new Date()).getTime())/1000)-now;


### PR DESCRIPTION
source cleanup

Changes proposed in this pull request:
- Remove declaration and presetting hour, min, sec on page load
- Declare hour, min, sec local in ticktac only
- Declare all other variables in ticktac as local: startsecoffset, sek, htmp, mtmp, stmp, titleclock
- Insert spaces and idents

Reason for this pull request:
- Variables startsecoffset, sek, hour, min, sec, htmp, mtmp, stmp, titleclock are local used only in ticktac
