### PR TITLE
startRecord without ts_ext_reload (resolves #493)

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -346,7 +346,6 @@ function startRecord(projectID,activityID,userID) {
             var data = jQuery.parseJSON(response);
             currentRecording = data['id'];
             $('#buzzer').removeClass('disabled');
-            ts_ext_reload();
         }
     );
 }


### PR DESCRIPTION
FIXES #493

Changes proposed in this pull request:
- Do not call extra ts_ext_reload

Reason for this pull request:
- ts_ext_reload is called via setTimeframe, via hook_timeframe_changed and  timesheet_extension_timeframe_changed
- ts_ext_reload should not call, if timesheet is not active. This will be perfect handled in timesheet_extension_timeframe_changed
