### PR TITLE
Bugfix: Check if user exists

### DIFF
--- a/extensions/ki_adminpanel/processor.php
+++ b/extensions/ki_adminpanel/processor.php
@@ -34,12 +34,20 @@ switch ($axAction)
         $groupsWithAddPermission = array();
         foreach ($kga['user']['groups'] as $group) {
             $membershipRoleID = $database->user_get_membership_role($kga['user']['userID'], $group);
-            if ($database->membership_role_allows($membershipRoleID, 'core-user-add'))
+            if ($database->membership_role_allows($membershipRoleID, 'core-user-add')) {
                 $groupsWithAddPermission[$group] = $membershipRoleID;
+            }
         }
 
         // validate data
         $errors = array();
+
+        // check if user exists already
+        if ($database->user_name2id($userData['name']) !== false) {
+            $errors[] = $kga['lang']['errorMessages']['userExistsAlready'];
+        }
+        
+        // check for customer with same name
         if ($database->customer_nameToID($userData['name']) !== false) {
             $errors[] = $kga['lang']['errorMessages']['customerWithSameName'];
         }

--- a/language/de.php
+++ b/language/de.php
@@ -338,6 +338,7 @@ EOD
     'errorMessages' => array(
         'permissionDenied' => 'Keine Berechtigung',
         'userWithSameName' => 'Kundennamen dürfen nicht gleich lauten wie Benutzernamen.',
+        'userExistsAlready' => 'Benutzer existiert bereits.',
         'customerWithSameName' => 'Benutzernamen dürfen nicht gleich lauten wie Kundennamen.',
         'sameGlobalRoleName' => 'Eine globale Rolle mit diesem Namen existiert bereits.',
         'sameMembershipRoleName' => 'Eine gruppenbezogene Rolle mit diesem Namen existiert bereits.',

--- a/language/en.php
+++ b/language/en.php
@@ -339,6 +339,7 @@ EOD
     'errorMessages' => array(
         'permissionDenied' => 'Permission denied',
         'userWithSameName' => 'A customer name can not be the same as a user name.',
+        'userExistsAlready' => 'User exists already.',
         'customerWithSameName' => 'A user name can not be the same as a customer name.',
         'sameGlobalRoleName' => 'A global role with this name already exists.',
         'sameMembershipRoleName' => 'A membership role with this name already exists.',


### PR DESCRIPTION
When creating a new user, a check is missing if the user exists already.

Resolves #701
