### PR TITLE
Fix cache directory

### DIFF
--- a/includes/basics.php
+++ b/includes/basics.php
@@ -83,7 +83,7 @@ if (!empty($vars)) {
 }
 
 $tmpDir = WEBROOT . 'temporary/';
-if (!file_exists($tmpDir) || !is_dir($tmpDir) ||!is_writable($tmpDir)) {
+if (!file_exists($tmpDir) || !is_dir($tmpDir) || !is_writable($tmpDir)) {
     die('Kimai needs write permissions for: temporary/');
 }
 

--- a/includes/basics.php
+++ b/includes/basics.php
@@ -81,3 +81,14 @@ if (!empty($vars)) {
         $kga['language'] = 'en';
     }
 }
+
+$tmpDir = WEBROOT . 'temporary/';
+if (!file_exists($tmpDir) || !is_dir($tmpDir) ||!is_writable($tmpDir)) {
+    die('Kimai needs write permissions for: temporary/');
+}
+
+$frontendOptions = array('lifetime' => 7200, 'automatic_serialization' => true);
+$backendOptions = array('cache_dir' => $tmpDir);
+$cache = Zend_Cache::factory('Core', 'File', $frontendOptions, $backendOptions);
+Kimai_Registry::setCache($cache);
+Zend_Locale::setCache($cache);

--- a/libraries/Kimai/Registry.php
+++ b/libraries/Kimai/Registry.php
@@ -63,4 +63,26 @@ class Kimai_Registry extends Zend_Registry
     {
         return self::get('Kimai_User');
     }
+
+    /**
+     * Sets the global cache object.
+     *
+     * @param Zend_Cache_Core $cache
+     */
+    public static function setCache(Zend_Cache_Core $cache)
+    {
+        self::set('Zend_Cache', $cache);
+    }
+
+    /**
+     * Returns the global cache object.
+     * This should be used, if you have no use for a dedicated cache.
+     *
+     * @return mixed
+     * @throws Zend_Exception
+     */
+    public static function getCache()
+    {
+        return self::get('Zend_Cache');
+    }
 }


### PR DESCRIPTION
FIXES #729

Changes proposed in this pull request:
- adds a global Zend_Cache object and injects it into Zend components, which are indirectly used

Reason for this pull request:
- some servers have no working temp/ directory configured 
- Kimai has a temporary/ directory, so we should use it
