### PR TITLE
Fix Kimai_Config Class error

### DIFF
--- a/libraries/composer/autoload_namespaces.php
+++ b/libraries/composer/autoload_namespaces.php
@@ -8,5 +8,5 @@ $baseDir = dirname($vendorDir);
 return array(
     'Zend_' => array($vendorDir . '/zendframework/zendframework1/library'),
     'PHPExcel' => array($vendorDir . '/phpoffice/phpexcel/Classes'),
-    'Kimai_' => array($vendorDir),
+    'Kimai_' => array($vendorDir . ''),
 );

--- a/libraries/composer/autoload_namespaces.php
+++ b/libraries/composer/autoload_namespaces.php
@@ -8,5 +8,5 @@ $baseDir = dirname($vendorDir);
 return array(
     'Zend_' => array($vendorDir . '/zendframework/zendframework1/library'),
     'PHPExcel' => array($vendorDir . '/phpoffice/phpexcel/Classes'),
-    'Kimai_' => array($vendorDir . ''),
+    'Kimai_' => array($vendorDir),
 );

--- a/libraries/composer/autoload_static.php
+++ b/libraries/composer/autoload_static.php
@@ -29,7 +29,7 @@ class ComposerStaticInit8c00ac27a90dfc4ac1a7acb480023ed4
         array (
             'Kimai_' => 
             array (
-                0 => 'C:\\xampp704\\htdocs\\kimai\\htdocs\\libraries',
+                0 => __DIR__ . '/../..' . '/libraries',
             ),
         ),
     );


### PR DESCRIPTION
FIXES #742

Changes proposed in this pull request:
- added empty path to namespace for `Kimai_` in `autoload_namespaces.php`

Reason for this pull request:
- without it installation fails
