### PR TITLE
Installer GPL checkbox

### DIFF
--- a/installer/installscript.js
+++ b/installer/installscript.js
@@ -80,8 +80,12 @@ function lang_selected(lang) {
 // -------------------------------------------------
 // Agree to GPL
 
-function gpl_agreed() {
-    $('#installsteps button.proceed').fadeIn('slow');
+function gpl_agreed(checkbox) {
+    if($(checkbox).prop('checked')) {
+        $('#installsteps button.proceed').fadeIn('slow');
+    } else {
+        $('#installsteps button.proceed').fadeOut();
+    }
 }
 
 function gpl_proceed() {

--- a/installer/steps/20_gpl.php
+++ b/installer/steps/20_gpl.php
@@ -8,7 +8,7 @@ EOD;
     require("20_gpl_en.php");
     echo <<<EOD
         </div>
-        <input type="checkbox" name="accept" value='1' onclick="gpl_agreed();" style="width:15px;height:15px;display:inline;">
+        <input type="checkbox" name="accept" value='1' onclick="gpl_agreed(this);" style="width:15px;height:15px;display:inline;">
         <span style="margin-top:5px">I agree to the terms of the General Public License.</span><br/>
         <!--<button onclick="step_back(); return false;" class="">Back</button>-->
         <button onclick="gpl_proceed(); return false;" class="invisible proceed">Proceed</button>
@@ -22,7 +22,7 @@ EOD;
     require("20_gpl_de.php");
     echo <<<EOD
         </div>
-        <input type="checkbox" name="accept" value='1' onclick="gpl_agreed();" style="width:15px;height:15px;display:inline;">
+        <input type="checkbox" name="accept" value='1' onclick="gpl_agreed(this);" style="width:15px;height:15px;display:inline;">
         <span style="margin-top:5px">Ich stimme den Bedingungen der General Public License zu.</span><br/>
         <!--<button onclick="step_back(); return false;" class="">Zurück</button>-->
         <button onclick="gpl_proceed(); return false;" class="invisible proceed">Fortfahren</button>


### PR DESCRIPTION
Changes proposed in this pull request:
- the "proceed installation" buttons only is visible if the "I accept the GPL" is checked

Reason for this pull request:
- Currently you can activate the "Accept GPL" checkbox, the "proceed" button will appear. Then you de-activate the checkbox and the button stays (indicating you don't have to accept GPL in order to install)
