### PR TITLE
fix the export summary in std_time by replacing gmdate with a new function

### DIFF
--- a/extensions/ki_export/base_export_pdf.php
+++ b/extensions/ki_export/base_export_pdf.php
@@ -96,20 +96,21 @@ class BasePDF extends TCPDF
 
         return sprintf('% 2d:%02d', $hours, $minutes);
     }
-    
+
     /**
      * Calculate time in hh:mm from duration lenght in second
      * rounded to minutes.
      *
-     * @param int $duration , duration lenght in second
+     * @param int $duration
+     *            , duration lenght in second
      * @return string time in format hh:mm
      */
     public function timeLength($duration)
     {
-        $s=$duration % 60;
-        $m=(($duration-$s) / 60) % 60;
-        $h=floor($duration / 3600);
-        return $h.":".substr("0".$m,-2)." ".$kga['lang']['export_extension']['duration_unit'];
+        $s = $duration % 60;
+        $m = (($duration - $s) / 60) % 60;
+        $h = floor($duration / 3600);
+        return $h . ":" . substr("0" . $m, - 2) . " " . $kga['lang']['export_extension']['duration_unit'];
     }
 
     /**

--- a/extensions/ki_export/base_export_pdf.php
+++ b/extensions/ki_export/base_export_pdf.php
@@ -109,7 +109,8 @@ class BasePDF extends TCPDF
         $s = $duration % 60;
         $m = (($duration - $s) / 60) % 60;
         $h = floor($duration / 3600);
-        return $h . ":" . substr('0' . $m, - 2) . " " . $kga['lang']['export_extension']['duration_unit'];
+        $timeLength =  $h . ":" . substr('0' . $m, - 2);
+        return $this->time_unit($timeLength);
     }
 
     /**

--- a/extensions/ki_export/base_export_pdf.php
+++ b/extensions/ki_export/base_export_pdf.php
@@ -96,6 +96,20 @@ class BasePDF extends TCPDF
 
         return sprintf('% 2d:%02d', $hours, $minutes);
     }
+    
+    /**
+     * calculate time in hh:mm from duration lenght in second
+     * rounded to minutes
+     * @param int $duration, duration lenght in second
+     * @return string time in format hh:mm
+     */
+    public function timeLength($duration)
+    {
+        $s=$duration % 60;
+        $m=(($duration-$s) / 60) % 60;
+        $h=floor($duration / 3600);
+        return $h.":".substr("0".$m,-2)." ".$kga['lang']['export_extension']['duration_unit'];
+    }
 
     /**
      * Format a number as a money value.
@@ -200,7 +214,7 @@ class BasePDF extends TCPDF
                 }
             } else {
                 if (isset($this->columns['time'])) {
-                    $this->Cell($w[1], 6, gmdate('H:i', $row['std_time']), 'LR', 0, 'R', $fill);
+                    $this->Cell($w[1], 6, $this->timeLength($row['std_time']), 'LR', 0, 'R', $fill);
                 }
             }
             if (isset($this->columns['wage'])) {
@@ -223,7 +237,7 @@ class BasePDF extends TCPDF
             }
         } else {
             if (isset($this->columns['time'])) {
-                $this->Cell($w[1], 6, gmdate('H:i', $sum_std_time), '', 0, 'R', true);
+                $this->Cell($w[1], 6, $this->timeLength($sum_std_time), '', 0, 'R', true);
             }
         }
         if (isset($this->columns['wage'])) {

--- a/extensions/ki_export/base_export_pdf.php
+++ b/extensions/ki_export/base_export_pdf.php
@@ -101,7 +101,7 @@ class BasePDF extends TCPDF
      * Calculate time in hh:mm from duration lenght in second
      * rounded to minutes.
      *
-     * @param int $duration , duration lenght in second
+     * @param int $duration lenght in second
      * @return string time in format hh:mm
      */
     public function timeLength($duration)

--- a/extensions/ki_export/base_export_pdf.php
+++ b/extensions/ki_export/base_export_pdf.php
@@ -98,9 +98,10 @@ class BasePDF extends TCPDF
     }
     
     /**
-     * calculate time in hh:mm from duration lenght in second
-     * rounded to minutes
-     * @param int $duration, duration lenght in second
+     * Calculate time in hh:mm from duration lenght in second
+     * rounded to minutes.
+     *
+     * @param int $duration , duration lenght in second
      * @return string time in format hh:mm
      */
     public function timeLength($duration)
@@ -130,7 +131,7 @@ class BasePDF extends TCPDF
      */
     public function printHeader($w, $header)
     {
-        // Colors, line width and bold font 
+        // Colors, line width and bold font
         $this->SetFillColor(240, 240, 240);
         $this->SetTextColor(0);
         $this->SetDrawColor(0, 0, 0);
@@ -168,10 +169,10 @@ class BasePDF extends TCPDF
             $w[0] -= 30;
         }
 
-        // Header 
+        // Header
         $this->printHeader($w, $header);
 
-        // Color and font restoration 
+        // Color and font restoration
         $this->SetFillColor(224, 235, 255);
         $this->SetTextColor(0);
         $this->SetFont('');
@@ -202,7 +203,7 @@ class BasePDF extends TCPDF
                 $this->AddPage();
                 $this->printHeader($w, $header);
 
-                // Color and font restoration 
+                // Color and font restoration
                 $this->SetFillColor(224, 235, 255);
                 $this->SetTextColor(0);
                 $this->SetFont('');

--- a/extensions/ki_export/base_export_pdf.php
+++ b/extensions/ki_export/base_export_pdf.php
@@ -101,8 +101,7 @@ class BasePDF extends TCPDF
      * Calculate time in hh:mm from duration lenght in second
      * rounded to minutes.
      *
-     * @param int $duration
-     *            , duration lenght in second
+     * @param int $duration , duration lenght in second
      * @return string time in format hh:mm
      */
     public function timeLength($duration)
@@ -110,7 +109,7 @@ class BasePDF extends TCPDF
         $s = $duration % 60;
         $m = (($duration - $s) / 60) % 60;
         $h = floor($duration / 3600);
-        return $h . ":" . substr("0" . $m, - 2) . " " . $kga['lang']['export_extension']['duration_unit'];
+        return $h . ":" . substr('0' . $m, - 2) . " " . $kga['lang']['export_extension']['duration_unit'];
     }
 
     /**


### PR DESCRIPTION
FIXES #770 

Changes proposed in this pull request:
-  in ki_export base_export_pdf.php I<ve replaced gmdate by a new function to fix the export summary in pdf export std-time

Reason for this pull request:
- The summary was showing wrong total time because gmdate cannot handle time length bigger then 24hrs.
