### PR TITLE
Authenticator settings via config file

### DIFF
--- a/libraries/Kimai/Auth/Abstract.php
+++ b/libraries/Kimai/Auth/Abstract.php
@@ -55,6 +55,27 @@ abstract class Kimai_Auth_Abstract
         if ($kga !== null) {
             $this->setKga($kga);
         }
+        if (file_exists(WEBROOT . 'includes/auth.php')) {
+            $config = include WEBROOT . 'includes/auth.php';
+            foreach ($config as $key => $value) {
+                $this->setConfig($key, $value);
+            }
+        }
+    }
+
+    /**
+     * Set one config value.
+     * By default it uses instance properties.
+     *
+     * @param $key
+     * @param $value
+     */
+    protected function setConfig($key, $value)
+    {
+        if (!isset($this->$key) || $key == 'kga' || $key == 'database') {
+            return;
+        }
+        $this->$key = $value;
     }
 
     /**

--- a/libraries/Kimai/Auth/ActiveDirectory.php
+++ b/libraries/Kimai/Auth/ActiveDirectory.php
@@ -18,20 +18,31 @@
  */
 
 /**
- * Authenticator to be used with Microsofts Active Directory and the activated
- * option "Enhanced Identity Privacy".
+ * Authenticator to be used with Microsofts Active Directory.
  *
- * See https://technet.microsoft.com/en-us/library/f351e0e3-6c78-49dc-9b0f-2b24e1b7411c
+ * Supports the "Enhanced Identity Privacy" option, see:
+ * https://technet.microsoft.com/en-us/library/f351e0e3-6c78-49dc-9b0f-2b24e1b7411c
  *
  * To activate this Authentication Adapter, add the following line to the
  * file ```includes/autoconf.php```
  *
  *     $authenticator = 'activeDirectory';
+ *
+ * To activate "Enhanced Identity Privacy" create the file includes/auth.php and
+ * activate at least the setting 'enhancedIdentityPrivacy':
+ *
+ *      return array('enhancedIdentityPrivacy' => true);
+ *
  */
 class Kimai_Auth_ActiveDirectory extends Kimai_Auth_Ldapadvanced
 {
+    protected $enhancedIdentityPrivacy = false;
+
     protected function createCheckUsername($username, $uidAttribute)
     {
-        return $this->forceLowercase ? strtolower($username) : $username;
+        if ($this->enhancedIdentityPrivacy) {
+            return $this->forceLowercase ? strtolower($username) : $username;
+        }
+        return parent::createCheckUsername($username, $uidAttribute);
     }
 }


### PR DESCRIPTION
FIXES #760

Changes proposed in this pull request:

allow to configure each authenticator class with a config file
Reason for this pull request:

Kimai updates would overwrite user settings made in e.g. https://github.com/kimai/kimai/blob/develop/libraries/Kimai/Auth/Ldapadvanced.php
