### PR TITLE
Authenticator: Exception if LDAP extension is not loaded

### DIFF
--- a/libraries/Kimai/Auth/Exception.php
+++ b/libraries/Kimai/Auth/Exception.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of
+ * Kimai - Open Source Time Tracking // http://www.kimai.org
+ * (c) Kimai-Development-Team since 2006
+ *
+ * Kimai is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; Version 3, 29 June 2007
+ *
+ * Kimai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Generic Authentication Exception.
+ */
+class Kimai_Auth_Exception extends RuntimeException
+{
+}

--- a/libraries/Kimai/Auth/Ldap.php
+++ b/libraries/Kimai/Auth/Ldap.php
@@ -62,14 +62,12 @@ class Kimai_Auth_Ldap extends Kimai_Auth_Abstract
     private $kimaiAuth = null;
 
     /**
-     * Kimai_Auth_Ldap constructor.
-     * @param null $database
-     * @param null $kga
+     * {@inherit}
      */
     public function __construct($database = null, $kga = null)
     {
         if (!function_exists('ldap_bind')) {
-            throw new InvalidArgumentException('LDAP-Extension is not installed');
+            throw new Kimai_Auth_Exception('LDAP-Extension is not installed');
         }
         parent::__construct($database, $kga);
         $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);

--- a/libraries/Kimai/Auth/Ldap.php
+++ b/libraries/Kimai/Auth/Ldap.php
@@ -25,41 +25,67 @@
 class Kimai_Auth_Ldap extends Kimai_Auth_Abstract
 {
 
-    /** Your LDAP-Server */
-    private $LADP_SERVER = 'ldap://localhost';
-    /** Case-insensitivity of some Servers may confuse the case-sensitive-accounting system. */
+    /**
+     * Your LDAP-Server
+     * @var string
+     */
+    private $LDAP_SERVER = 'ldap://localhost';
+    /**
+     * Case-insensitivity of some server may confuse the case-sensitive-accounting system
+     * @var bool
+     */
     private $LDAP_FORCE_USERNAME_LOWERCASE = true;
-    /** Preprends to username */
+    /**
+     * Prefix for username in LDAP query
+     * @var string
+     */
     private $LDAP_USERNAME_PREFIX = 'cn=';
-    /** Appends to username */
+    /**
+     * Postfix for username in LDAP query
+     * @var string
+     */
     private $LDAP_USERNAME_POSTFIX = ',dc=example,dc=com';
-    /** Accounts that sould be locally verified */
+    /**
+     * Accounts that should be verified locally only (in Kimai database)
+     * @var array
+     */
     private $LDAP_LOCAL_ACCOUNTS = array('admin');
-    /** Automatically create a user in kimai if the login is successful. */
+    /**
+     * Automatically create a user in kimai if the login is successful
+     * @var bool
+     */
     private $LDAP_USER_AUTOCREATE = true;
     /**
-     * @var Kimai_Auth_Kimai|null
+     * The original Kimai authenticator for local authentication and user creation.
+     * @var Kimai_Auth_Kimai
      */
     private $kimaiAuth = null;
 
+    /**
+     * Kimai_Auth_Ldap constructor.
+     * @param null $database
+     * @param null $kga
+     */
     public function __construct($database = null, $kga = null)
     {
+        if (!function_exists('ldap_bind')) {
+            throw new InvalidArgumentException('LDAP-Extension is not installed');
+        }
         parent::__construct($database, $kga);
         $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);
     }
 
+    /**
+     * @param string $username
+     * @param string $password
+     * @param int $userId
+     * @return bool
+     */
     public function authenticate($username, $password, &$userId)
     {
         // Check if username should be authenticated locally
         if (in_array($username, $this->LDAP_LOCAL_ACCOUNTS)) {
             return $this->kimaiAuth->authenticate($username, $password, $userId);
-        }
-
-        // Check environment sanity
-        if (!function_exists('ldap_bind')) {
-            echo 'ldap is not installed!';
-            $userId = false;
-            return false;
         }
 
         // Check if username is legal
@@ -71,9 +97,9 @@ class Kimai_Auth_Ldap extends Kimai_Auth_Abstract
         }
 
         // Connect to LDAP
-        $connect_result = ldap_connect($this->LADP_SERVER);
+        $connect_result = ldap_connect($this->LDAP_SERVER);
         if (!$connect_result) {
-            echo "Cannot connect to ", $this->LADP_SERVER;
+            echo "Cannot connect to ", $this->LDAP_SERVER;
             $userId = false;
             return false;
         }

--- a/libraries/Kimai/Auth/Ldapadvanced.php
+++ b/libraries/Kimai/Auth/Ldapadvanced.php
@@ -182,7 +182,7 @@ class Kimai_Auth_Ldapadvanced extends Kimai_Auth_Abstract
     public function __construct($database = null, $kga = null)
     {
         if (!function_exists('ldap_bind')) {
-            throw new InvalidArgumentException('LDAP-Extension is not installed');
+            throw new Kimai_Auth_Exception('LDAP-Extension is not installed');
         }
         parent::__construct($database, $kga);
         $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);


### PR DESCRIPTION
Changes proposed in this pull request:
- throw exception if LDAP extension is not loaded
- phpdoc improvements

Reason for this pull request:
- LDAP classes should behave the same way (see Ldapadvanced)
