### PR TITLE
[BUGFIX] Column 'value' cannot be null

### DIFF
--- a/extensions/ki_adminpanel/processor.php
+++ b/extensions/ki_adminpanel/processor.php
@@ -437,16 +437,16 @@ switch ($axAction)
             $config_data['adminmail'] = $_REQUEST['adminmail'];
             $config_data['loginTries'] = $_REQUEST['logintries'];
             $config_data['loginBanTime'] = $_REQUEST['loginbantime'];
-            $config_data['show_sensible_data'] = getRequestBool($_REQUEST['show_sensible_data']);
-            $config_data['show_update_warn'] = getRequestBool($_REQUEST['show_update_warn']);
-            $config_data['check_at_startup'] = getRequestBool($_REQUEST['check_at_startup']);
-            $config_data['show_daySeperatorLines'] = getRequestBool($_REQUEST['show_daySeperatorLines']);
-            $config_data['show_gabBreaks'] = getRequestBool($_REQUEST['show_gabBreaks']);
-            $config_data['show_RecordAgain'] = getRequestBool($_REQUEST['show_RecordAgain']);
-            $config_data['show_TrackingNr'] = getRequestBool($_REQUEST['show_TrackingNr']);
+            $config_data['show_sensible_data'] = getRequestBool('show_sensible_data');
+            $config_data['show_update_warn'] = getRequestBool('show_update_warn');
+            $config_data['check_at_startup'] = getRequestBool('check_at_startup');
+            $config_data['show_daySeperatorLines'] = getRequestBool('show_daySeperatorLines');
+            $config_data['show_gabBreaks'] = getRequestBool('show_gabBreaks');
+            $config_data['show_RecordAgain'] = getRequestBool('show_RecordAgain');
+            $config_data['show_TrackingNr'] = getRequestBool('show_TrackingNr');
             $config_data['currency_name'] = $_REQUEST['currency_name'];
             $config_data['currency_sign'] = $_REQUEST['currency_sign'];
-            $config_data['currency_first'] = getRequestBool($_REQUEST['currency_first']);
+            $config_data['currency_first'] = getRequestBool('currency_first');
             $config_data['date_format_0'] = $_REQUEST['date_format_0'];
             $config_data['date_format_1'] = $_REQUEST['date_format_1'];
             $config_data['date_format_2'] = $_REQUEST['date_format_2'];
@@ -456,15 +456,15 @@ switch ($axAction)
                 $config_data['status'] = implode(',', $_REQUEST['status']);
             }
             $config_data['roundPrecision'] = $_REQUEST['roundPrecision'];
-            $config_data['allowRoundDown'] = getRequestBool($_REQUEST['allowRoundDown']);
+            $config_data['allowRoundDown'] = getRequestBool('allowRoundDown');
             $config_data['roundMinutes'] = $_REQUEST['roundMinutes'];
             $config_data['roundSeconds'] = $_REQUEST['roundSeconds'];
             $config_data['roundTimesheetEntries'] = $_REQUEST['roundTimesheetEntries'];
             $config_data['decimalSeparator'] = $_REQUEST['decimalSeparator'];
-            $config_data['durationWithSeconds'] = getRequestBool($_REQUEST['durationWithSeconds']);
-            $config_data['exactSums'] = getRequestBool($_REQUEST['exactSums']);
+            $config_data['durationWithSeconds'] = getRequestBool('durationWithSeconds');
+            $config_data['exactSums'] = getRequestBool('exactSums');
             $editLimit = false;
-            if (getRequestBool($_REQUEST['editLimitEnabled'])) {
+            if (getRequestBool('editLimitEnabled')) {
                 $hours = (int)$_REQUEST['editLimitHours'];
                 $days = (int)$_REQUEST['editLimitDays'];
                 $editLimit = $hours + $days * 24;


### PR DESCRIPTION
In getRequestBool the value was checked like this:

``` php
$_REQUEST[$_REQUEST[$name]]
```

but it should be checked like this:

``` php
$_REQUEST[$name]
```

FIXES: #738 
