### PR TITLE
[BUGFIX] only call updater when database changes

### DIFF
--- a/includes/func.php
+++ b/includes/func.php
@@ -235,7 +235,6 @@ function checkDBversion($path)
     // check for versions before 0.7.13r96
     $installedVersion = $database->get_DBversion();
     $checkVersion = $installedVersion[0];
-    $checkVersion = "$checkVersion";
 
     if ($checkVersion == "0.5.1" && count($database->get_users()) == 0) {
         // fresh install
@@ -243,7 +242,8 @@ function checkDBversion($path)
         exit;
     }
 
-    if ($checkVersion != $config->getVersion() || (int)$installedVersion[1] < $config->getRevision()) {
+    // only call updater when database changes no matter the kimai version
+    if ((int)$installedVersion[1] < $config->getRevision()) {
         header("Location: $path/updater/updater.php");
         exit;
     }

--- a/index.php
+++ b/index.php
@@ -36,8 +36,7 @@ checkDBversion(".");
 // ==========================
 // = installation required? =
 // ==========================
-if (count($database->get_users()) == 0)
-{
+if (count($database->get_users()) == 0) {
     $view->assign('devtimespan', '2006-' . date('y'));
     if (isset($_REQUEST['disagreedGPL'])) {
         $view->assign('disagreedGPL', 1);
@@ -111,8 +110,7 @@ if (!$justLoggedOut && $authPlugin->autoLoginPossible() && $authPlugin->performA
 // =================================================================
 // = processing login and displaying either login screen or errors =
 // =================================================================
-switch ($_REQUEST['a'])
-{
+switch ($_REQUEST['a']) {
 
     case 'checklogin':
         $is_customer = $database->is_customer_name($name);

--- a/updater/updater.php
+++ b/updater/updater.php
@@ -67,8 +67,7 @@ unset($version_temp);
 // ================================================================================
 // Display starting screen before executing the Update finally
 // ================================================================================
-if (!isset($_REQUEST['a']) && $kga['show_update_warn'] == 1)
-{
+if (!isset($_REQUEST['a']) && $kga['show_update_warn'] == 1) {
     exitUpdater(
         'UPDATE',
         $kga['lang']['updater'][0] . '
@@ -83,8 +82,7 @@ if (!isset($_REQUEST['a']) && $kga['show_update_warn'] == 1)
 // ================================================================================
 // timezone was introduced, give the user an option to select the default one
 // ================================================================================
-if ((int)$revisionDB < 1219 && !isset($_REQUEST['timezone']))
-{
+if ((int)$revisionDB < 1219 && !isset($_REQUEST['timezone'])) {
     $timeZonesOptions = '';
     $serverZone = @date_default_timezone_get();
 


### PR DESCRIPTION
Changes proposed in this pull request:
- call the updater only when database changes

Reason for this pull request:
- updater is also called when kimai version changes without database changes. This will result in an endless loop.
