### PR TITLE
Fix array init for PHP 7.1

### DIFF
--- a/extensions/ext_debug/processor.php
+++ b/extensions/ext_debug/processor.php
@@ -39,7 +39,7 @@ switch ($axAction)
         $i = 0;
         
         $lines = $kga['logfile_lines'];
-        $filearray = "";
+        $filearray = [];
         
         while (!feof($fh)) {
             $filearray[$i] = fgets($fh);


### PR DESCRIPTION
Fixes empty logfile output inside debug extension

Changes proposed in this pull request:
- Init the `$filearray` variable as an array instead of a string.

Reason for this pull request:
- Seems like some array handling has been changed in PHP 7.1 leading to an empty logfile output inside the debug extension.
