### PR TITLE
[FEATURE] Confirm toggle of cleared entries in export module

### DIFF
--- a/extensions/ki_export/js/xp_func.js
+++ b/extensions/ki_export/js/xp_func.js
@@ -329,6 +329,25 @@ function export_toggle_column(name) {
 }
 
 /**
+ * Check if any checked entrys are in the list and confirm toggle if there are any.
+ */
+function export_toogle_cleared_confirm() {
+	var checked_elements = 0;
+	$('#xptable td.cleared>a').each(function() {
+		if ($(this).hasClass("is_cleared")) {
+			checked_elements++;
+		}
+	});
+	if (checked_elements > 0) {
+		// TODO: add translations somehow
+		if (!confirm('There are ' + checked_elements + ' already cleared entries!\nDo you really want to set these entries to uncleared?')) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
  * Toggle the cleared state of an entry.
  */
 function export_toggle_cleared(id) {

--- a/extensions/ki_export/templates/scripts/main.php
+++ b/extensions/ki_export/templates/scripts/main.php
@@ -60,7 +60,7 @@
                 <a onclick="export_toggle_column('user');" title="<?php echo $this->kga['lang']['username'] ?>"><?php echo $this->ellipsis($this->kga['lang']['username'], 4) ?></a>
             </td>
             <td class="cleared">
-                <a onclick="$('#xptable td.cleared>a').click(); return false;">invert</a>
+                <a onclick="if (export_toogle_cleared_confirm()) { $('#xptable td.cleared>a').click(); }; return false;">invert</a>
             </td>
         </tr>
         </tbody>


### PR DESCRIPTION
FIXES #

Changes proposed in this pull request:
- in the export tool it is possible to toggle entries from cleared to uncleared. We added a simple alert message to ask if the already cleared entries should really be set to uncleared.

Reason for this pull request:
- we had some issues in the past. This message helped us a lot to notice that there are already cleared entries in the list
![toggleclearedentries](https://user-images.githubusercontent.com/3355651/29410474-de130916-8350-11e7-9194-822756fcd43a.png)

