### PR TITLE
[BUGFIX] show description header also if tracking numbers are not activated

### DIFF
--- a/extensions/ki_timesheets/templates/scripts/main.php
+++ b/extensions/ki_timesheets/templates/scripts/main.php
@@ -17,8 +17,8 @@
             <col class="customer"/>
             <col class="project"/>
             <col class="activity"/>
+            <col class="description"/>
             <?php if ($this->showTrackingNumber) { ?>
-                <col class="description"/>
                 <col class="trackingnumber"/>
             <?php } ?>
             <col class="username"/>

--- a/extensions/ki_timesheets/templates/scripts/main.php
+++ b/extensions/ki_timesheets/templates/scripts/main.php
@@ -36,8 +36,8 @@
             <td class="customer"><?php echo $this->kga['lang']['customer'] ?></td>
             <td class="project"><?php echo $this->kga['lang']['project'] ?></td>
             <td class="activity"><?php echo $this->kga['lang']['activity'] ?></td>
+            <td class="description"><?php echo $this->kga['lang']['description'] ?></td>
             <?php if ($this->showTrackingNumber) { ?>
-                <td class="description"><?php echo $this->kga['lang']['description'] ?></td>
                 <td class="trackingnumber"><?php echo $this->kga['lang']['trackingNumber'] ?></td>
             <?php } ?>
             <td class="username"><?php echo $this->kga['lang']['username'] ?></td>


### PR DESCRIPTION

FIXES #

Changes proposed in this pull request:
- fix wrong table header position for description

Reason for this pull request:
- the position of the header had to be outside of tracking number check