### PR TITLE
[FEATURE] preset end day to the value of start day if other date/time…

### DIFF
--- a/extensions/ki_timesheets/js/ts_func.js
+++ b/extensions/ki_timesheets/js/ts_func.js
@@ -519,6 +519,13 @@ function ts_getEndDate() {
 	return ts_getDateFromStrings($("#end_day").val(), $("#end_time").val());
 }
 
+function ts_prefillEndDate() {
+	if (!$("#end_day").val()) {
+		$("#end_day").val($("#start_day").val());
+		$('#end_day').trigger('change');
+	}
+}
+
 /**
  * Change the end time field, based on the duration, while editing a timesheet record
  */

--- a/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
+++ b/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
@@ -84,7 +84,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                     <li>
                         <label for="start_day"><?php echo $this->kga['lang']['day'] ?>:</label>
                         <input id='start_day' type='text' name='start_day' value='<?php echo $this->escape($this->start_day) ?>' maxlength='10' size='10' tabindex='6'
-                               onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                               onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         -
                         <input id='end_day' type='text' name='end_day' value='<?php echo $this->escape($this->end_day) ?>' maxlength='10' size='10' tabindex='7'
                                onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />

--- a/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
+++ b/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
@@ -84,7 +84,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                     <li>
                         <label for="start_day"><?php echo $this->kga['lang']['day'] ?>:</label>
                         <input id='start_day' type='text' name='start_day' value='<?php echo $this->escape($this->start_day) ?>' maxlength='10' size='10' tabindex='6'
-                               onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                               onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         -
                         <input id='end_day' type='text' name='end_day' value='<?php echo $this->escape($this->end_day) ?>' maxlength='10' size='10' tabindex='7'
                                onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
@@ -93,10 +93,10 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         <label for="start_time"><?php echo $this->kga['lang']['timelabel'] ?>:</label>
                         <input id='start_time' type='text' name='start_time'
                                value='<?php echo $this->escape($this->start_time) ?>' maxlength='8' size='8' tabindex='8'
-                               onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                               onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         -
                         <input id='end_time' type='text' name='end_time' value='<?php echo $this->escape($this->end_time) ?>' maxlength='8' size='8' tabindex='9'
-                               onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                               onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         <a id="currentTime" href="#" onclick="pasteNow(); ts_timeToDuration(); $(this).blur(); return false;"><?php echo $this->kga['lang']['now'] ?></a>
                     </li>
                     <li>


### PR DESCRIPTION
… values are changed and the end day was not set before

Changes proposed in this pull request:
- prefill end date in timesheet floater on change of other time/date values. The prefill value will be the value of the start day. The end day will only be changed if there is not already a value inserted.

Reason for this pull request:
- This is also speed improvement for us. While adding entries e.g. from handwritten lists it is more convenient when the end day will be set if you change/add the end time. This improves/speeds up this task quite a bit.
