### PR TITLE
[BUGFIX] Only set end day to start day if end time is changed in time…

### DIFF
--- a/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
+++ b/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
@@ -93,7 +93,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         <label for="start_time"><?php echo $this->kga['lang']['timelabel'] ?>:</label>
                         <input id='start_time' type='text' name='start_time'
                                value='<?php echo $this->escape($this->start_time) ?>' maxlength='8' size='8' tabindex='8'
-                               onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                               onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         -
                         <input id='end_time' type='text' name='end_time' value='<?php echo $this->escape($this->end_time) ?>' maxlength='8' size='8' tabindex='9'
                                onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />


### PR DESCRIPTION
…sheet edit floater. Otherwise it was not possible to just change the start time anymore.

Changes proposed in this pull request:
- [BUGFIX] The automatic setting of the end day while changing the start TIME in the timesheet entry edit floater made it impossible to just change the start time because the floater did not close anymore.

Reason for this pull request:
- We use the automatic end day setting in most cases with setting the end time. Here this features works very well (you can just enter a end time and press enter and the floater closes and sets the right time). But in other cases in which you only adapt you start time it was not possible to close the floater anymore without setting a endtime. So this change fixes this now and still keeps the in our use case quite important feature of quickly adding entries.
