### PR TITLE
[Bugfix] Description text with special letters is not shown

### DIFF
--- a/templates/helpers/Truncate.php
+++ b/templates/helpers/Truncate.php
@@ -33,9 +33,16 @@ class Zend_View_Helper_Truncate extends Zend_View_Helper_Abstract
      */
     public function truncate($text, $maxLength, $append = '')
     {
-        if (strlen($text) > $maxLength) {
-            return substr($text, 0, $maxLength) . $append;
+    	if (extension_loaded('mbstring')) {
+			if (mb_strlen($text) > $maxLength) {
+				return mb_substr($text, 0, $maxLength) . $append;
+			}
+        } else {
+			if (strlen($text) > $maxLength) {
+				return substr($text, 0, $maxLength) . $append;
+			}
         }
+        
 
         return $text;
     }

--- a/templates/helpers/Truncate.php
+++ b/templates/helpers/Truncate.php
@@ -33,16 +33,15 @@ class Zend_View_Helper_Truncate extends Zend_View_Helper_Abstract
      */
     public function truncate($text, $maxLength, $append = '')
     {
-    	if (extension_loaded('mbstring')) {
-			if (mb_strlen($text) > $maxLength) {
-				return mb_substr($text, 0, $maxLength) . $append;
-			}
+        if (extension_loaded('mbstring')) {
+            if (mb_strlen($text) > $maxLength) {
+                return mb_substr($text, 0, $maxLength) . $append;
+            }
         } else {
-			if (strlen($text) > $maxLength) {
-				return substr($text, 0, $maxLength) . $append;
-			}
-        }
-        
+            if (strlen($text) > $maxLength) {
+                return substr($text, 0, $maxLength) . $append;
+            }
+        }     
 
         return $text;
     }


### PR DESCRIPTION
FIXES #1072 

Use mb_strlen and mb_substring if PHP mbstring-extension is enabled (Otherwise use the "old" functions as fallback)
