### PR TITLE
Add SAML authentication with onelogin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "tecnickcom/tcpdf": "^6.2.12",
         "zendframework/zendframework1": "^1.12",
         "phpoffice/phpexcel": "1.8.*",
-        "tinybutstrong/tinybutstrong": "^3.10"
+        "tinybutstrong/tinybutstrong": "^3.10",
+        "onelogin/php-saml": "^2.12"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,61 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "096359b77016a53ca38310fe725a16aa",
+    "content-hash": "e148ed63ce9ab602f06c15fa7d023bf2",
     "packages": [
+        {
+            "name": "onelogin/php-saml",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/onelogin/php-saml.git",
+                "reference": "9416fa739cff88ffcc472967cec048a774b97e0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/onelogin/php-saml/zipball/9416fa739cff88ffcc472967cec048a774b97e0f",
+                "reference": "9416fa739cff88ffcc472967cec048a774b97e0f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-mcrypt": "*",
+                "ext-openssl": "*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "pdepend/pdepend": "1.1.0",
+                "phploc/phploc": "*",
+                "phpunit/phpunit": "4.8",
+                "satooshi/php-coveralls": "1.0.1",
+                "sebastian/phpcpd": "*",
+                "squizlabs/php_codesniffer": "2.9.0"
+            },
+            "suggest": {
+                "ext-gettext": "Install gettext and php5-gettext libs to handle translations"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "extlib/xmlseclibs",
+                    "lib/Saml",
+                    "lib/Saml2"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "OneLogin PHP SAML Toolkit",
+            "homepage": "https://developers.onelogin.com/saml/php",
+            "keywords": [
+                "SAML2",
+                "onelogin",
+                "saml"
+            ],
+            "time": "2017-11-06T17:44:03+00:00"
+        },
         {
             "name": "phpoffice/phpexcel",
             "version": "1.8.1",

--- a/index.php
+++ b/index.php
@@ -70,6 +70,9 @@ $justLoggedOut = false;
 if ($_REQUEST['a'] == 'logout') {
     setcookie('kimai_key', '0');
     setcookie('kimai_user', '0');
+    if (!empty($userId)) {
+        $database->user_loginSetKey($userId, 0);
+    }
     $justLoggedOut = true;
 }
 
@@ -79,6 +82,33 @@ if (isset($_COOKIE['kimai_user']) && isset($_COOKIE['kimai_key']) && $_COOKIE['k
         header('Location: core/kimai.php');
         exit;
     }
+}
+
+// ======================================
+// = Check for SAML login               =
+//=======================================
+if ($kga['authenticator'] == 'saml' && $_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['SAMLResponse'])) {
+
+    $authPlugin->processResponse($_POST['SAMLResponse'], $userId);
+
+    if ($userId === false) {
+        $userId = $database->user_create(array(
+            'name' => $name,
+            'globalRoleID' => $authPlugin->getDefaultGlobalRole(),
+            'active' => 1
+        ));
+        $database->setGroupMemberships($userId, array($authPlugin->getDefaultGroups()));
+    }
+    $userData = $database->user_get_data($userId);
+
+    $loginKey = random_code(30);
+    setcookie('kimai_key', $loginKey);
+    setcookie('kimai_user', $userData['name']);
+
+    $database->user_loginSetKey($userId, $loginKey);
+
+    header('Location: core/kimai.php');
+    exit;
 }
 
 // if possible try an automatic login

--- a/libraries/Kimai/Auth/Saml.php
+++ b/libraries/Kimai/Auth/Saml.php
@@ -1,0 +1,386 @@
+<?php
+/**
+ * This file is part of
+ * Kimai - Open Source Time Tracking // http://www.kimai.org
+ * (c) Kimai-Development-Team since 2006
+ *
+ * Kimai is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; Version 3, 29 June 2007
+ *
+ * Kimai is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kimai; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Saml authentication based on standard Kimai auth
+ */
+class Kimai_Auth_Saml extends Kimai_Auth_Abstract
+{
+    /**
+     * Shall we have strict SAML checks enforced?
+     *
+     * @var boolean $saml_strict
+     */
+    protected $saml_strict = true;
+
+    /**
+     * Enable SAML debugging?
+     *
+     * @var boolean $saml_debug
+     */
+    protected $saml_debug = true;
+
+    /**
+     * The SAML base URL
+     *
+     * @var string $saml_baseurl
+     */
+    protected $saml_baseurl = '';
+
+    /**
+     * The SAML Service Provider Entity ID
+     *
+     * @var string $saml_spentityId
+     */
+    protected $saml_spentityId = 'https://kimai.local/libraries/onelogin/php-saml/demo2/metadata.php';
+
+    /**
+     * The SAML Service Provider ACS URL
+     *
+     * @var string saml_spacsURL
+     */
+    protected $saml_spacsURL = 'https://kimai.local/index.php';
+
+    /**
+     * The SAML Service Provider SLS URL
+     *
+     * @var string $saml_spslsURL
+     */
+    protected $saml_spslsURL = 'https://kimai.local/index.php';
+
+    /**
+     * The SAML Service Provider x509 Certificate
+     *
+     * @var string $saml_spx509cert
+     */
+    protected $saml_spx509cert = '';
+
+    /**
+     * The SAML Service Provider private key
+     *
+     * @var string $saml_spprivateKey
+     */
+    protected $saml_spprivateKey = '';
+
+    /**
+     * The SAML Identity Provider entityId
+     *
+     * @var string $saml_idpentityId
+     */
+    protected $saml_idpentityId = 'https://accounts.google.com/o/saml2?idpid=#########';
+
+    /**
+     * The SAML Identity Provider SSO URL
+     *
+     * @var string $saml_idpssoURL
+     */
+    protected $saml_idpssoURL = 'https://accounts.google.com/o/saml2/idp?idpid=#########';
+
+    /**
+     * The SAML Identity Provider SLS URL
+     *
+     * @var string $saml_idpslsURL
+     */
+    protected $saml_idpslsURL = '';
+
+    /**
+     * The SAML Identity Provider Certificate Fingerprint
+     *
+     * @var string $saml_idpcertFingerprint
+     */
+    protected $saml_idpcertFingerprint = 'AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA';
+
+    /**
+     * The SAML Identity Provider Certificate Fingerprint Algorithim
+     *
+     * @var string $saml_idpcertFingerprintAlgorithm
+     */
+    protected $saml_idpcertFingerprintAlgorithm = 'sha1';
+
+    /**
+     * Accounts that should be verified locally.
+     *
+     * All entries in this array will not be checked against the SAML
+     *
+     * @var array $nonSAMLAccounts
+     */
+    protected $nonSAMLAcounts = array(
+        'admin'
+    );
+
+    /**
+     * The name of the default global role the user should be added to.
+     *
+     * @var string $defaultGlobalRoleName
+     */
+    protected $defaultGlobalRoleName = 'User';
+
+    /**
+     * Map of group=>role names for new users
+     *
+     * @var array $defaultGroupMemberships
+     */
+    protected $defaultGroupMemberships = array(
+        'Users' => 'User',
+    );
+
+    /**
+     * The text to remove from the beginning of a username.
+     *
+     * @var string $removeUsernamePrefix
+     */
+    protected $removeUsernamePrefix = '';
+
+    /**
+     * The text to remove from the end of a username.
+     *
+     * @var string $removeUsernameSuffix
+     */
+    protected $removeUsernameSuffix = '';
+
+    /**
+     * {@inherit}
+     */
+    public function __construct($database = null, $kga = null)
+    {
+        parent::__construct($database, $kga);
+        $this->kimaiAuth = new Kimai_Auth_Kimai($database, $kga);
+
+        $this->saml_settings = array(
+            'strict' => $this->saml_strict,
+            'debug' => $this->saml_debug,
+            'baseurl' => $this->saml_baseurl,
+            'sp' => array(
+                'entityId' => $this->saml_spentityId,
+                'assertionConsumerService' => array(
+                    'url' => $this->saml_spacsURL,
+                    'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                ),
+                'singleLogoutService' => array(
+                    'url' => $this->saml_spslsURL,
+                    'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                ),
+                'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
+                'x509cert' => $this->saml_spx509cert,
+                'privateKey' => $this->saml_spprivateKey,
+            ),
+            'idp' => array(
+                'entityId' => $this->saml_idpentityId,
+                'singleSignOnService' => array(
+                    'url' => $this->saml_idpssoURL,
+                    'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                ),
+                'singleLogoutService' => array(
+                    'url' => $this->saml_idpslsURL,
+                    'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
+                ),
+                'certFingerprint' => $this->saml_idpcertFingerprint,
+                'certFingerprintAlgorithm' => $this->saml_idpcertFingerprintAlgorithm,
+            ),
+        );
+    }
+
+    /**
+     * Decides whether this authentication method should be used to authenticate
+     * users before they have provided any credentials.
+     *
+     * This allows users to be logged in automatically. Mostly used with SSO (single sign on) solutions.
+     *
+     * @return boolean <code>true</code> if this authentication method can login users without credentials,
+     *   <code>false</code> otherwise
+     */
+    public function autoLoginPossible()
+    {
+        // This is cannot be set to false for Saml Authentication
+        return true;
+    }
+
+    /**
+     * Try to authenticate the user before he sees the login page.
+     *
+     * @param int $userId is set to the id of the user. If none exists it will be false
+     * @return boolean either true if the user could be authenticated or false otherwise
+     */
+    public function performAutoLogin(&$userId)
+    {
+        Kimai_Logger::logfile("SAML: performAutoLogin");
+
+        $userId = false;
+        $check_username = '';
+        if (!isset($_SESSION['samlUserdata'])) {
+            Kimai_Logger::logfile("SAML: samlUserdata not set");
+            $settings = new OneLogin_Saml2_Settings($this->saml_settings);
+            $authRequest = new OneLogin_Saml2_AuthnRequest($settings);
+            $samlRequest = $authRequest->getRequest();
+
+            $parameters = array('SAMLRequest' => $samlRequest);
+            $parameters['RelayState'] = OneLogin_Saml2_Utils::getSelfURLNoQuery();
+
+            $idpData = $settings->getIdPData();
+            $ssoUrl = $idpData['singleSignOnService']['url'];
+            $url = OneLogin_Saml2_Utils::redirect($ssoUrl, $parameters, true);
+
+            header("Location: $url");
+        }
+        return false;
+    }
+
+    public function processResponse($idpResponse, &$userId)
+    {
+        Kimai_Logger::logfile("SAML: processResponse");
+        $auth = new OneLogin_Saml2_Auth($this->saml_settings);
+        $auth->processResponse();
+        $errors = $auth->getErrors();
+
+        if (!empty($errors)) {
+            foreach ($errors as $error) {
+                Kimai_Logger::logfile("SAML: Errors: " . $error);
+            }
+            exit();
+        }
+
+        $settings = new OneLogin_Saml2_Settings($this->saml_settings);
+        $samlResponse = new OneLogin_Saml2_Response($settings, $idpResponse);
+        if (!$auth->isAuthenticated()) {
+            Kimai_Logger::logfile("SAML: Not authenticated");
+            exit();
+        }
+        if ($samlResponse->isValid()) {
+            Kimai_Logger::logfile("SAML: You are: " . $samlResponse->getNameId());
+            $check_username = $samlResponse->getNameId();
+            $attributes = $samlResponse->getAttributes();
+            if (!empty($attributes)) {
+                $alias = $attributes['fn'][0] . " " . $attributes['ln'][0];
+                $mail = $attributes['mail'][0];
+            }
+        } else {
+            Kimai_Logger::logfile("SAML: Invalid SAML Response");
+            return false;
+        }
+        // Remove the prefix and suffix from the user name
+        $lenprefix = strlen($this->removeUsernamePrefix);
+        if (substr(strtoupper($check_username), 0, $lenprefix) == strtoupper($this->removeUsernamePrefix)) {
+            $check_username = substr($check_username, $lenprefix);
+        }
+
+        $suffixStart = strlen($check_username)-strlen($this->removeUsernameSuffix);
+        if (substr(strtoupper($check_username), $suffixStart, strlen($check_username)) == strtoupper($this->removeUsernameSuffix)) {
+            $check_username = substr($check_username, 0, $suffixStart);
+        }
+
+        $userId = $this->database->user_name2id($check_username);
+
+        if ($userId !== false) {
+            Kimai_Logger::logfile("SAML: Username: " . $check_username . " exists!");
+            return true;
+        } else {
+            $userId = $this->database->user_create(array(
+                'name' => $check_username,
+                'globalRoleID' => $this->getDefaultGlobalRole(),
+                'active' => 1,
+                'password' => encode_password(md5(uniqid(rand(), true)))
+            ));
+
+            $this->database->setGroupMemberships($userId, $this->getDefaultGroups());
+            // Set a password, to calm kimai down
+            $usr_data = array('password' => md5($this->kga['password_salt'] . md5(uniqid(rand(), true)) . $this->kga['password_salt']));
+            if ($mail) {
+                $usr_data['mail'] = $mail;
+            }
+            if ($alias) {
+                $usr_data['alias'] = $alias;
+            }
+            $this->database->user_edit($userId, $usr_data);
+            return true;
+        }
+    }
+
+    /**
+     * Get the default global role
+     *
+     * @return integer
+     */
+    public function getDefaultGlobalRole()
+    {
+        if ($this->defaultGlobalRoleName) {
+            $database = $this->getDatabase();
+
+            $roles = $database->global_roles();
+
+            foreach ($roles as $role) {
+                if ($role['name'] == $this->defaultGlobalRoleName) {
+                    return $role['globalRoleID'];
+                }
+            }
+        }
+
+        return parent::getDefaultGlobalRole();
+    }
+
+    /**
+     * Get a map of group=>role associations for new users
+     *
+     * @return array
+     */
+    public function getDefaultGroups()
+    {
+        $groups = array();
+        $roles  = array();
+        $map    = array();
+
+        $database = $this->getDatabase();
+        foreach ($database->membership_roles() as $role) {
+            $roles[$role['name']] = $role['membershipRoleID'];
+        }
+
+        foreach ($database->get_groups() as $group) {
+            $groups[$group['name']] = $group['groupID'];
+        }
+
+        foreach ($this->defaultGroupMemberships as $group => $role) {
+            if (!isset($groups[$group])) {
+                continue;
+            }
+            if (!isset($roles[$role])) {
+                continue;
+            }
+
+            $map[$groups[$group]] = $roles[$role];
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param string $username
+     * @param string $password
+     * @param int $userId
+     * @return bool
+     */
+    public function authenticate($username, $password, &$userId)
+    {
+        // Check if username should be authenticated locally
+        if (in_array($username, $this->nonSAMLAcounts)) {
+            Kimai_Logger::logfile("SAML: Local Authentication for: " .$username);
+            return $this->kimaiAuth->authenticate($username, $password, $userId);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
FIXES #961 #960 

Changes proposed in this pull request:
- 
Addition of SAML Authenticator.  Allows you to authenticate to Kimai via SAML.  Tested against Google's GSuite SAML Identity Provider. Supports MS ADFS and Google for Work authentication.

Reason for this pull request:
- 
More eyes on the code.  Anyone wanting to test contact me and I can provide a temporary account on my GSuite domain.

Documentation:
- 
https://github.com/kimai/documentation/pull/10