### PR TITLE
Bugfix: Clear expenses separately from timesheet entries

### DIFF
--- a/extensions/ki_invoice/private_func.php
+++ b/extensions/ki_invoice/private_func.php
@@ -83,6 +83,7 @@ function invoice_get_data($start, $end, $projects, $filter_cleared, $short_form)
         foreach($expenses as $entry) {
             $arr = ext_invoice_empty_entry();
 
+            $arr['expenseID'] = $entry['expenseID'];
             $arr['type'] = 'expense';
             $arr['desc'] = $entry['designation'];
             $arr['start'] = $entry['timestamp'];


### PR DESCRIPTION
Changes proposed in this pull request:
- Clear expenses separately from timesheet entries

Reason for this pull request:
- Clearing of entries was only possible when there were no expenses. With expenses resulted in a mysql error.
