### PR TITLE
Fixing time offset calculation on GUI

### DIFF
--- a/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -263,9 +263,10 @@ if ($this->timeSheetEntries) {
     $('#display_total').html(ts_total);
 
     <?php if ($this->latest_running_entry == null): ?>
-    updateRecordStatus(false);
+    updateRecordStatus(<?php echo time(); ?>, false);
     <?php else: ?>
     updateRecordStatus(
+        <?php echo time(); ?>,
         <?php echo $this->latest_running_entry['timeEntryID']?>,
         <?php echo $this->latest_running_entry['start']?>,
         <?php echo $this->latest_running_entry['customerID']?>,

--- a/js/main.js
+++ b/js/main.js
@@ -361,7 +361,7 @@ function stopRecord() {
     );
 }
 
-function updateRecordStatus(record_ID, record_startTime, customerID, customerName, projectID, projectName, activityID, activityName) { // Updated
+function updateRecordStatus(serverTime, record_ID, record_startTime, customerID, customerName, projectID, projectName, activityID, activityName ) { // Updated
     // if awaiting updateRecordStatus from buzzer
     if (typeof timeout_updateRecordStatus != 'undefined'){
         clearTimeout(timeout_updateRecordStatus);
@@ -375,11 +375,9 @@ function updateRecordStatus(record_ID, record_startTime, customerID, customerNam
         show_selectors();
         return;
     }
-
-    // Update offset accuracy
-    if ( typeof stopwatch_init_time != 'undefined' && (stopwatch_init_time + offset) != record_startTime ){
-        offset = stopwatch_init_time - record_startTime;
-    }
+    
+    // calculate offset (note: this does not take into account network latencies - but I guess for display this should be accurate enough)
+    var offset = serverTime - ((new Date()).getTime() / 1000);
 
     startsec = record_startTime + offset;
 
@@ -396,7 +394,6 @@ function show_stopwatch() {
     $("#ticker_project").html($("#selected_project").html());
     $("#ticker_activity").html($("#selected_activity").html());
     $("ul#ticker").newsticker();
-    stopwatch_init_time = Math.floor((new Date()).getTime() / 1000);
     ticktac();
 }
 
@@ -516,7 +513,6 @@ function ticktac() {
 function ticktack_off() {
     if (timeoutTicktack) {
         clearTimeout(timeoutTicktack);
-        delete stopwatch_init_time;
         timeoutTicktack = 0;
         $("#h").html("00");
         $("#m").html("00");

--- a/libraries/Kimai/Remote/Database.php
+++ b/libraries/Kimai/Remote/Database.php
@@ -207,9 +207,9 @@ class Kimai_Remote_Database
 
         $query = "$select
   			FROM ${p}expenses e
-	  		Join ${p}projects p USING(e.projectID)
-	  		Join ${p}customers p USING(p.customerID)
-	  		Join ${p}users u USING(e.userID)
+	  		Join ${p}projects p USING(projectID)
+	  		Join ${p}customers c USING(customerID)
+	  		Join ${p}users u USING(userID)
 	  		$where
 	  		ORDER BY timestamp $orderDirection $limit";
 


### PR DESCRIPTION
FIXES #905 / #1047

Changes proposed in this pull request:
- Fixing time synchronisation code - this can only be done by combining server and client timestamp - not on the client only as proposed in the last pull

Reason for this pull request:
- Invalid offset calculation
