### PR TITLE
Use translate method instead of accessing the lang string directly

### DIFF
--- a/extensions/ki_adminpanel/processor.php
+++ b/extensions/ki_adminpanel/processor.php
@@ -25,9 +25,8 @@ $database = Kimai_Registry::getDatabase();
 
 require 'functions.php';
 
-switch ($axAction)
-{
-    case "createUser" :
+switch ($axAction) {
+    case 'createUser':
         // create new user account
         $userData['name'] = trim($axValue);
         $userData['globalRoleID'] = $kga['user']['globalRoleID'];
@@ -73,7 +72,7 @@ switch ($axAction)
         );
         break;
 
-    case "createStatus" :
+    case 'createStatus':
         $status_data['status'] = trim($axValue);
 
         // validate data
@@ -95,7 +94,7 @@ switch ($axAction)
         );
         break;
 
-    case "createGroup" :
+    case 'createGroup' :
         $group['name'] = trim($axValue);
 
         // validate data
@@ -117,12 +116,11 @@ switch ($axAction)
         );
         break;
 
-    case "refreshSubtab" :
+    case 'refreshSubtab' :
         $viewOtherGroupsAllowed = $database->global_role_allows($kga['user']['globalRoleID'], 'core-group-otherGroup-view');
 
-        switch ($axValue)
-        {
-            case "users":
+        switch ($axValue) {
+            case 'users':
                 $userData = getUsersData($database, $kga['user'], $viewOtherGroupsAllowed);
                 foreach($userData as $key => $value) {
                     $view->assign($key, $value);
@@ -130,7 +128,7 @@ switch ($axAction)
                 echo $view->render('users.php');
                 break;
 
-            case "groups":
+            case 'groups':
                 $groupsData = getGroupsData($database, $kga['user'], $viewOtherGroupsAllowed);
                 foreach($groupsData as $key => $value) {
                     $view->assign($key, $value);
@@ -138,16 +136,16 @@ switch ($axAction)
                 echo $view->render('groups.php');
                 break;
 
-            case "status":
+            case 'status':
                 $view->assign('statuses', $database->get_statuses());
                 echo $view->render('status.php');
                 break;
 
-            case "database" :
+            case 'database':
                 echo $view->render('database.php');
                 break;
 
-            case "customers" :
+            case 'customers':
                 $customersData = getCustomersData($database, $kga['user'], $viewOtherGroupsAllowed);
                 foreach ($customersData as $key => $value) {
                     $view->assign($key, $value);
@@ -155,7 +153,7 @@ switch ($axAction)
                 echo $view->render('customers.php');
                 break;
 
-            case "projects" :
+            case 'projects':
                 $projectsData = getProjectsData($database, $kga['user'], $viewOtherGroupsAllowed);
                 foreach ($projectsData as $key => $value) {
                     $view->assign($key, $value);
@@ -163,7 +161,7 @@ switch ($axAction)
                 echo $view->render('projects.php');
                 break;
 
-            case "activities" :
+            case 'activities':
                 $activitiesData = getActivitiesData($database, $kga['user'], $viewOtherGroupsAllowed);
                 foreach($activitiesData as $key => $data) {
                     $view->assign($key, $data);
@@ -171,19 +169,19 @@ switch ($axAction)
                 echo $view->render('activities.php');
                 break;
 
-            case "globalRoles":
+            case 'globalRoles':
                 $view->assign('globalRoles', $database->global_roles());
                 echo $view->render('globalRoles.php');
                 break;
 
-            case "membershipRoles":
+            case 'membershipRoles':
                 $view->assign('membershipRoles', $database->membership_roles());
                 echo $view->render('membershipRoles.php');
                 break;
         }
         break;
 
-    case "deleteUser":
+    case 'deleteUser':
         $oldGroups = $database->getGroupMemberships($id);
         $errors = [];
 
@@ -223,7 +221,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteGroup" :
+    case 'deleteGroup':
         $errors = [];
 
         if (!checkGroupedObjectPermission('group', 'delete', [$id], [$id])) {
@@ -243,7 +241,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteStatus" :
+    case 'deleteStatus':
         $errors = [];
         if (!isset($kga['user']) || !$database->global_role_allows($kga['user']['globalRoleID'], 'core-status-delete')) {
             $errors[''] = $kga['lang']['errorMessages']['permissionDenied'];
@@ -262,7 +260,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteProject" :
+    case 'deleteProject':
         $errors = [];
         $oldGroups = $database->project_get_groupIDs($id);
 
@@ -284,7 +282,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteCustomer" :
+    case 'deleteCustomer':
         $errors = [];
         $oldGroups = $database->customer_get_groupIDs($id);
 
@@ -305,7 +303,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteActivity" :
+    case 'deleteActivity':
         $errors = [];
         $oldGroups = $database->activity_get_groupIDs($id);
 
@@ -326,22 +324,21 @@ switch ($axAction)
         );
         break;
 
-    case "banUser" :
+    case 'banUser':
         // Ban a user from login
         $sts['active'] = 0;
         $database->user_edit($id, $sts);
-        echo sprintf("<img border='0' title='%s' alt='%s' src='../skins/%s/grfx/lock.png' width='16' height='16' />", $kga['lang']['bannedUser'], $kga['lang']['bannedUser'], $view->skin()->getName());
+        echo sprintf('<img border="0" title="%s" alt="%s" src="../skins/%s/grfx/lock.png" width="16" height="16" />', $kga['lang']['bannedUser'], $kga['lang']['bannedUser'], $view->skin()->getName());
         break;
 
-    case "unbanUser" :
+    case 'unbanUser':
         // Unban a user from login
         $sts['active'] = 1;
         $database->user_edit($id, $sts);
-        echo sprintf("<img border='0' title='%s' alt='%s' src='../skins/%s/grfx/jipp.gif' width='16' height='16' />", $kga['lang']['activeAccount'], $kga['lang']['activeAccount'], $view->skin()->getName());
+        echo sprintf('<img border="0" title="%s" alt="%s" src="../skins/%s/grfx/jipp.gif" width="16" height="16" />', $kga['lang']['activeAccount'], $kga['lang']['activeAccount'], $view->skin()->getName());
         break;
 
-    case "sendEditUser" :
-
+    case 'sendEditUser':
         // process editUser form
         $userData['name'] = trim($_REQUEST['name']);
         $userData['mail'] = $_REQUEST['mail'];
@@ -383,7 +380,7 @@ switch ($axAction)
         );
         break;
 
-    case "sendEditGroup" :
+    case 'sendEditGroup':
         // process editGroup form
         $group['name'] = trim($_REQUEST['name']);
 
@@ -405,7 +402,7 @@ switch ($axAction)
         );
         break;
 
-    case "sendEditStatus" :
+    case 'sendEditStatus':
         // process editStatus form
         $status_data['status'] = trim($_REQUEST['status']);
 
@@ -428,7 +425,7 @@ switch ($axAction)
         );
         break;
 
-    case "sendEditAdvanced" :
+    case 'sendEditAdvanced':
         $errors = [];
         if (!isset($kga['user']) || !$database->global_role_allows($kga['user']['globalRoleID'], 'adminPanel_extension-editAdvanced')) {
             $errors[''] = $kga['lang']['errorMessages']['permissionDenied'];
@@ -505,11 +502,11 @@ switch ($axAction)
         );
         break;
 
-    case "toggleDeletedUsers" :
+    case 'toggleDeletedUsers' :
         setcookie("adminPanel_extension_show_deleted_users", $axValue);
         break;
 
-    case "createGlobalRole":
+    case 'createGlobalRole':
         $role_data['name'] = trim($axValue);
 
         $errors = [];
@@ -533,7 +530,7 @@ switch ($axAction)
         );
         break;
 
-    case "createMembershipRole":
+    case 'createMembershipRole':
         $role_data['name'] = trim($axValue);
 
         $errors = [];
@@ -559,7 +556,7 @@ switch ($axAction)
         );
         break;
 
-    case "editGlobalRole":
+    case 'editGlobalRole':
         $id = $_REQUEST['id'];
         $newData = $_REQUEST;
         unset($newData['id']);
@@ -593,7 +590,7 @@ switch ($axAction)
         );
         break;
 
-    case "editMembershipRole":
+    case 'editMembershipRole':
         $id = $_REQUEST['id'];
         $newData = $_REQUEST;
         unset($newData['id']);
@@ -627,7 +624,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteGlobalRole":
+    case 'deleteGlobalRole':
         $errors = [];
 
         if (!isset($kga['user'])) {
@@ -646,7 +643,7 @@ switch ($axAction)
         );
         break;
 
-    case "deleteMembershipRole":
+    case 'deleteMembershipRole':
         $errors = [];
 
         if (!isset($kga['user'])) {

--- a/extensions/ki_adminpanel/templates/scripts/activities.php
+++ b/extensions/ki_adminpanel/templates/scripts/activities.php
@@ -1,8 +1,8 @@
-<a href="#" onclick="floaterShow('floaters.php','add_edit_activity',0,0,500); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->kga['lang']['new_activity']?>"></a> <?php echo $this->kga['lang']['new_activity']?>
-&nbsp;&nbsp;&nbsp;<?php echo $this->kga['lang']['view_filter']?>:
+<a href="#" onclick="floaterShow('floaters.php','add_edit_activity',0,0,500); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->translate('new_activity')?>"></a> <?php echo $this->translate('new_activity')?>
+&nbsp;&nbsp;&nbsp;<?php echo $this->translate('view_filter')?>:
 <select size="1" id="activity_project_filter" onchange="adminPanel_extension_refreshSubtab('activities');">
-	<option value="-2" <?php if ($this->selected_activity_filter == -2): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['unassigned']?></option>
-	<option value="-1" <?php if ($this->selected_activity_filter == -1): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['all_activities']?></option>
+	<option value="-2" <?php if ($this->selected_activity_filter == -2): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('unassigned')?></option>
+	<option value="-1" <?php if ($this->selected_activity_filter == -1): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('all_activities')?></option>
 	<?php foreach ($this->projects as $row): ?>
 	<option value="<?php echo $row['projectID']?>"
 		<?php if ($this->selected_activity_filter==$row['projectID']): ?> selected="selected"<?php endif; ?>> <?php echo $this->escape($row['name']),' (', $this->escape($this->truncate($row['customerName'],30,"..."))?>)</option>
@@ -12,10 +12,10 @@
 <table>
 	<thead>
 		<tr class="headerrow">
-			<th width="80"><?php echo $this->kga['lang']['options']?></th>
-			<th width="25%"><?php echo $this->kga['lang']['activity']?></th>
-			<th><?php echo $this->kga['lang']['projects']?></th>
-			<th width="25%"><?php echo $this->kga['lang']['groups']?></th>
+			<th width="80"><?php echo $this->translate('options')?></th>
+			<th width="25%"><?php echo $this->translate('activity')?></th>
+			<th><?php echo $this->translate('projects')?></th>
+			<th width="25%"><?php echo $this->translate('groups')?></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -33,10 +33,10 @@
 			<tr class="<?php echo $this->cycle(["odd", "even"])->next()?>">
 				<td class="option">
 					<a href="#" onclick="editSubject('activity',<?php echo $activity['activityID']?>); $(this).blur(); return false;">
-						<img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['edit']?>" title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
+						<img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt="<?php echo $this->translate('edit')?>" title="<?php echo $this->translate('edit')?>" border="0" /></a>
 					&nbsp;
 					<a href="#" id="delete_activity<?php echo $activity['activityID']?>" onclick="adminPanel_extension_deleteActivity(<?php echo $activity['activityID']?>)">
-						<img src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_activity']?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_activity']?>" border="0"></a>
+						<img src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->translate('delete_activity')?>" width="13" height="13" alt="<?php echo $this->translate('delete_activity')?>" border="0"></a>
 				</td>
 				<td class="activities <?php if ($isHidden) { echo 'hidden'; } ?>">
 					<?php echo $this->escape($activity['name']); ?>

--- a/extensions/ki_adminpanel/templates/scripts/advanced.php
+++ b/extensions/ki_adminpanel/templates/scripts/advanced.php
@@ -4,69 +4,69 @@
         <input name="axAction" type="hidden" value="sendEditAdvanced" />
         <fieldset class="adminPanel_extension_advanced">
             <div>
-                <input type="text" name="adminmail" size="20" value="<?php echo $this->escape($this->kga->getAdminEmail()) ?>" class="formfield"> <?php echo $this->kga['lang']['adminmail']?>
+                <input type="text" name="adminmail" size="20" value="<?php echo $this->escape($this->kga->getAdminEmail()) ?>" class="formfield"> <?php echo $this->translate('adminmail')?>
             </div>
             <div>
-                <input type="text" name="logintries" size="2" value="<?php echo $this->escape($this->kga->getLoginTriesBeforeBan()) ?>" class="formfield"> <?php echo $this->kga['lang']['logintries']?>
+                <input type="text" name="logintries" size="2" value="<?php echo $this->escape($this->kga->getLoginTriesBeforeBan()) ?>" class="formfield"> <?php echo $this->translate('logintries')?>
             </div>
             <div>
-                <input type="text" name="loginbantime" size="4" value="<?php echo $this->escape($this->kga->getLoginBanTime()) ?>" class="formfield"> <?php echo $this->kga['lang']['bantime']?>
+                <input type="text" name="loginbantime" size="4" value="<?php echo $this->escape($this->kga->getLoginBanTime()) ?>" class="formfield"> <?php echo $this->translate('bantime')?>
             </div>
             <div id="adminPanel_extension_checkupdate">
-                <a href="javascript:adminPanel_extension_checkupdate();"><?php echo $this->kga['lang']['checkupdate']?></a>
+                <a href="javascript:adminPanel_extension_checkupdate();"><?php echo $this->translate('checkupdate')?></a>
             </div>
             <div>
-                <?php echo $this->kga['lang']['lang']?>:
+                <?php echo $this->translate('lang')?>:
                 <?php echo $this->formSelect('language', $this->kga->getLanguage(true), ['class' => 'formfield'], array_combine($this->languages, $this->languages)); ?>
             </div>
 
             <div>
-                <input type="checkbox" name="show_update_warn" <?php if ($this->kga['show_update_warn']): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['show_update_warn']?>
+                <input type="checkbox" name="show_update_warn" <?php if ($this->kga['show_update_warn']): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('show_update_warn')?>
             </div>
             <div>
-                <input type="checkbox" name="check_at_startup" <?php if ($this->kga['check_at_startup']): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['check_at_startup']?>
+                <input type="checkbox" name="check_at_startup" <?php if ($this->kga['check_at_startup']): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('check_at_startup')?>
             </div>
             <div>
-                <input type="checkbox" name="show_daySeperatorLines" <?php if ($this->kga->isShowDaySeperatorLines()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['show_daySeperatorLines']?>
+                <input type="checkbox" name="show_daySeperatorLines" <?php if ($this->kga->isShowDaySeperatorLines()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('show_daySeperatorLines')?>
             </div>
             <div>
-                <input type="checkbox" name="show_gabBreaks" <?php if ($this->kga->isShowGabBreaks()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['show_gabBreaks']?>
+                <input type="checkbox" name="show_gabBreaks" <?php if ($this->kga->isShowGabBreaks()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('show_gabBreaks')?>
             </div>
             <div>
-                <input type="checkbox" name="show_RecordAgain" <?php if ($this->kga->isShowRecordAgain()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['show_RecordAgain']?>
+                <input type="checkbox" name="show_RecordAgain" <?php if ($this->kga->isShowRecordAgain()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('show_RecordAgain')?>
             </div>
             <div>
-                <input type="checkbox" name="show_TrackingNr" <?php if ($this->kga->isTrackingNumberEnabled()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['show_TrackingNr']?>
+                <input type="checkbox" name="show_TrackingNr" <?php if ($this->kga->isTrackingNumberEnabled()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('show_TrackingNr')?>
             </div>
             <div>
-                <input type="text" name="currency_name" size="8" value="<?php echo $this->escape($this->kga->getCurrencyName()) ?>" class="formfield"> <?php echo $this->kga['lang']['currency_name']?>
+                <input type="text" name="currency_name" size="8" value="<?php echo $this->escape($this->kga->getCurrencyName()) ?>" class="formfield"> <?php echo $this->translate('currency_name')?>
             </div>
             <div>
-                <input type="text" name="currency_sign" size="2" value="<?php echo $this->escape($this->kga->getCurrencySign()) ?>" class="formfield"> <?php echo $this->kga['lang']['currency_sign']?>
+                <input type="text" name="currency_sign" size="2" value="<?php echo $this->escape($this->kga->getCurrencySign()) ?>" class="formfield"> <?php echo $this->translate('currency_sign')?>
             </div>
             <div>
-                <input type="checkbox" name="currency_first" <?php if ($this->kga->isDisplayCurrencyFirst()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['currency_first']?>
+                <input type="checkbox" name="currency_first" <?php if ($this->kga->isDisplayCurrencyFirst()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('currency_first')?>
             </div>
             <div>
-                <input type="text" name="date_format_2" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(2)) ?>" class="formfield"> <?php echo $this->kga['lang']['display_date_format']?>
+                <input type="text" name="date_format_2" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(2)) ?>" class="formfield"> <?php echo $this->translate('display_date_format')?>
             </div>
             <div>
-                <input type="text" name="date_format_0" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(0)) ?>" class="formfield"> <?php echo $this->kga['lang']['date_format_0']?>
+                <input type="text" name="date_format_0" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(0)) ?>" class="formfield"> <?php echo $this->translate('date_format_0')?>
             </div>
             <div>
-                <input type="text" name="date_format_3" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(3)) ?>" class="formfield"> <?php echo $this->kga['lang']['date_format_3']?>
+                <input type="text" name="date_format_3" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(3)) ?>" class="formfield"> <?php echo $this->translate('date_format_3')?>
             </div>
             <div>
-                <input type="text" name="date_format_1" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(1)) ?>" class="formfield"> <?php echo $this->kga['lang']['table_date_format']?>
+                <input type="text" name="date_format_1" size="15" value="<?php echo $this->escape($this->kga->getDateFormat(1)) ?>" class="formfield"> <?php echo $this->translate('table_date_format')?>
             </div>
             <div>
-                <input type="text" name="table_time_format" size="15" value="<?php echo $this->escape($this->kga->getTableTimeFormat()) ?>" class="formfield"> <?php echo $this->kga['lang']['table_time_format']?>
+                <input type="text" name="table_time_format" size="15" value="<?php echo $this->escape($this->kga->getTableTimeFormat()) ?>" class="formfield"> <?php echo $this->translate('table_time_format')?>
             </div>
             <div>
-                <input type="checkbox" name="durationWithSeconds" <?php if ($this->kga['conf']['durationWithSeconds']): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['durationWithSeconds']?>
+                <input type="checkbox" name="durationWithSeconds" <?php if ($this->kga['conf']['durationWithSeconds']): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('durationWithSeconds')?>
             </div>
             <div>
-                <?php echo $this->kga['lang']['round_time']?> <select name="roundPrecision" class="formfield">
+                <?php echo $this->translate('round_time')?> <select name="roundPrecision" class="formfield">
                     <option value="0" <?php if ($this->kga->getRoundPrecisionRecorderTimes() == 0): ?> selected="selected" <?php endif; ?>>-</option>
                     <option value="1" <?php if ($this->kga->getRoundPrecisionRecorderTimes() == 1): ?> selected="selected" <?php endif; ?>>1</option>
                     <option value="5" <?php if ($this->kga->getRoundPrecisionRecorderTimes() == 5): ?> selected="selected" <?php endif; ?>>5</option>
@@ -74,30 +74,30 @@
                     <option value="15" <?php if ($this->kga->getRoundPrecisionRecorderTimes() == 15): ?> selected="selected" <?php endif; ?>>15</option>
                     <option value="15" <?php if ($this->kga->getRoundPrecisionRecorderTimes() == 20): ?> selected="selected" <?php endif; ?>>20</option>
                     <option value="30" <?php if ($this->kga->getRoundPrecisionRecorderTimes() == 30): ?> selected="selected" <?php endif; ?>>30</option>
-                </select> <?php echo $this->kga['lang']['round_time_minute']?> <input type="checkbox" name="allowRoundDown" <?php if($this->kga->isRoundDownRecorderTimes()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['allowRoundDown'];?>
+                </select> <?php echo $this->translate('round_time_minute')?> <input type="checkbox" name="allowRoundDown" <?php if($this->kga->isRoundDownRecorderTimes()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('allowRoundDown');?>
             </div>
             <div>
-                <?php echo $this->kga['lang']['decimal_separator']?>: <input type="text" name="decimalSeparator" size="1" value="<?php echo $this->escape($this->kga['conf']['decimalSeparator']) ?>" class="formfield">
+                <?php echo $this->translate('decimal_separator')?>: <input type="text" name="decimalSeparator" size="1" value="<?php echo $this->escape($this->kga['conf']['decimalSeparator']) ?>" class="formfield">
             </div>
             <div>
                 <?php echo $this->formSelect('defaultTimezone', $this->kga['defaultTimezone'], null, array_combine($this->timezones, $this->timezones));
-                echo $this->kga['lang']['defaultTimezone']?>
+                echo $this->translate('defaultTimezone')?>
             </div>
             <div>
-                <input type="checkbox" name="exactSums" <?php if ($this->kga->isUseExactSums()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->kga['lang']['exactSums']?>
+                <input type="checkbox" name="exactSums" <?php if ($this->kga->isUseExactSums()): ?> checked="checked" <?php endif; ?> value="1" class="formfield"> <?php echo $this->translate('exactSums')?>
             </div>
             <div <?php if (!$this->editLimitEnabled): ?> class="disabled" <?php endif; ?>>
-                <input type="checkbox" name="editLimitEnabled" value="1" <?php if ($this->editLimitEnabled): ?> checked="checked" <?php endif; ?> class="formfield, disableInput"> <?php echo $this->kga['lang']['editLimitPart1']?>
-                <input type="text" name="editLimitDays" size="3" class="formfield" value="<?php echo $this->editLimitDays?>" <?php if (!$this->editLimitEnabled): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->kga['lang']['editLimitPart2']?>
-                <input type="text" name="editLimitHours" size="3" class="formfield" value="<?php echo $this->editLimitHours?>" <?php if (!$this->editLimitEnabled): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->kga['lang']['editLimitPart3']?>
+                <input type="checkbox" name="editLimitEnabled" value="1" <?php if ($this->editLimitEnabled): ?> checked="checked" <?php endif; ?> class="formfield, disableInput"> <?php echo $this->translate('editLimitPart1')?>
+                <input type="text" name="editLimitDays" size="3" class="formfield" value="<?php echo $this->editLimitDays?>" <?php if (!$this->editLimitEnabled): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->translate('editLimitPart2')?>
+                <input type="text" name="editLimitHours" size="3" class="formfield" value="<?php echo $this->editLimitHours?>" <?php if (!$this->editLimitEnabled): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->translate('editLimitPart3')?>
             </div>
             <div <?php if (!$this->roundTimesheetEntries): ?> class="disabled" <?php endif; ?>>
-                <input type="checkbox" name="roundTimesheetEntries" value="1" <?php if ($this->roundTimesheetEntries): ?> checked="checked" <?php endif; ?> class="formfield, disableInput"> <?php echo $this->kga['lang']['roundTimesheetEntries']?>
-                <input type="text" name="roundMinutes" size="3" class="formfield" value="<?php echo $this->roundMinutes?>" <?php if (!$this->roundTimesheetEntries): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->kga['lang']['minutes']?> <?php echo $this->kga['lang']['and']?>
-                <input type="text" name="roundSeconds" size="3" class="formfield" value="<?php echo $this->roundSeconds?>" <?php if (!$this->roundTimesheetEntries): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->kga['lang']['seconds']?>
+                <input type="checkbox" name="roundTimesheetEntries" value="1" <?php if ($this->roundTimesheetEntries): ?> checked="checked" <?php endif; ?> class="formfield, disableInput"> <?php echo $this->translate('roundTimesheetEntries')?>
+                <input type="text" name="roundMinutes" size="3" class="formfield" value="<?php echo $this->roundMinutes?>" <?php if (!$this->roundTimesheetEntries): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->translate('minutes')?> <?php echo $this->translate('and')?>
+                <input type="text" name="roundSeconds" size="3" class="formfield" value="<?php echo $this->roundSeconds?>" <?php if (!$this->roundTimesheetEntries): ?> disabled="disabled" <?php endif; ?>> <?php echo $this->translate('seconds')?>
             </div>
             <div id="formbuttons">
-                <input id="adminPanel_extension_form_editadv_submit" class="btn_ok" type="submit" value="<?php echo $this->kga['lang']['save']?>" />
+                <input id="adminPanel_extension_form_editadv_submit" class="btn_ok" type="submit" value="<?php echo $this->translate('save')?>" />
             </div>
         </fieldset>
     </form>

--- a/extensions/ki_adminpanel/templates/scripts/customers.php
+++ b/extensions/ki_adminpanel/templates/scripts/customers.php
@@ -1,12 +1,12 @@
-<a href="#" onclick="floaterShow('floaters.php','add_edit_customer',0,0,450); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->kga['lang']['new_customer']?>"></a> <?php echo $this->kga['lang']['new_customer']?>
+<a href="#" onclick="floaterShow('floaters.php','add_edit_customer',0,0,450); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->translate('new_customer')?>"></a> <?php echo $this->translate('new_customer')?>
 <br/><br/>
 <table>
 	<thead>
 		<tr class="headerrow">
-			<th width="80px"><?php echo $this->kga['lang']['options']?></th>
-			<th width="25%"><?php echo $this->kga['lang']['customer']?></th>
-			<th><?php echo $this->kga['lang']['contactPerson']?></th>
-			<th width="25%"><?php echo $this->kga['lang']['groups']?></th>
+			<th width="80px"><?php echo $this->translate('options')?></th>
+			<th width="25%"><?php echo $this->translate('customer')?></th>
+			<th><?php echo $this->translate('contactPerson')?></th>
+			<th width="25%"><?php echo $this->translate('groups')?></th>
 		</tr>
 	</thead>
 	<tbody>
@@ -24,12 +24,12 @@
 			<tr class="<?php echo $this->cycle(["odd", "even"])->next()?>">
 				<td class="option">
 					<a href="#" onclick="editSubject('customer',<?php echo $row['customerID']?>); $(this).blur(); return false;"><img
-						src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['edit']?>"
-						title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
+						src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt="<?php echo $this->translate('edit')?>"
+						title="<?php echo $this->translate('edit')?>" border="0" /></a>
 					&nbsp;
 					<a href="#" id="delete_customer<?php echo $row['customerID']?>" onclick="adminPanel_extension_deleteCustomer(<?php echo $row['customerID']?>)"><img
-						src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_customer']?>"
-						width="13" height="13" alt="<?php echo $this->kga['lang']['delete_customer']?>" border="0"></a>
+						src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->translate('delete_customer')?>"
+						width="13" height="13" alt="<?php echo $this->translate('delete_customer')?>" border="0"></a>
 				</td>
 				<td class="clients <?php if ($isHidden) { echo 'hidden'; } ?>">
 					<?php echo $this->escape($row['name']);?>

--- a/extensions/ki_adminpanel/templates/scripts/floaters/editglobalrole.php
+++ b/extensions/ki_adminpanel/templates/scripts/floaters/editglobalrole.php
@@ -9,14 +9,14 @@ $this->getHelper('ParseHierarchy')->parseHierarchy($this->permissions, $extensio
     <div id="floater_handle">
         <span id="floater_title"><?php echo $this->title ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <?php
@@ -25,7 +25,7 @@ $this->getHelper('ParseHierarchy')->parseHierarchy($this->permissions, $extensio
 
                 $name = $key;
                 if (isset($this->kga['lang']['extensions'][$name]))
-                    $name = $this->kga['lang']['extensions'][$name];
+                    $name = $this->translate('extensions:' . $name);
                 ?>
                 <li class="tab norm"><a href="#<?php echo $key ?>">
                         <span class="aa">&nbsp;</span>
@@ -42,19 +42,19 @@ $this->getHelper('ParseHierarchy')->parseHierarchy($this->permissions, $extensio
             <fieldset id="general">
                 <ul>
                     <li>
-                        <label for="name"><?php echo $this->kga['lang']['rolename'] ?>:</label>
+                        <label for="name"><?php echo $this->translate('rolename') ?>:</label>
                         <input class="formfield" type="text" name="name" id="name" value="<?php echo $this->escape($this->name) ?>"/>
                     </li>
                 </ul>
                 <fieldset class="floatingTabLayout">
                     <?php if (count($extensions) > 0): ?>
-                        <legend><?php echo $this->kga['lang']['extensionsTitle']; ?></legend>
+                        <legend><?php echo $this->translate('extensionsTitle'); ?></legend>
                         <?php
                     endif;
                     foreach ($extensions as $key => $value):
                         $name = $key;
                         if (isset($this->kga['lang']['extensions'][$name]))
-                            $name = $this->kga['lang']['extensions'][$name];
+                            $name = $this->translate('extensions:' . $name);
                         ?>
                         <span class="permission"><input type="checkbox" value="1" name="<?php echo $key ?>-access" <?php if ($value == 1): ?> checked="checked" <?php endif; ?> /><?php echo $name ?></span>
                     <?php endforeach; ?>
@@ -63,8 +63,8 @@ $this->getHelper('ParseHierarchy')->parseHierarchy($this->permissions, $extensio
             <?php $this->echoHierarchy($this->kga, $keyHierarchy); ?>
         </div>
         <div id="formbuttons">
-            <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-            <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	        <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	        <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>

--- a/extensions/ki_adminpanel/templates/scripts/floaters/editgroup.php
+++ b/extensions/ki_adminpanel/templates/scripts/floaters/editgroup.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['editGroup'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('editGroup') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="floater_content">
@@ -12,13 +12,13 @@
             <fieldset>
                 <ul>
                     <li>
-                        <label for="name"><?php echo $this->kga['lang']['groupname'] ?>:</label>
+                        <label for="name"><?php echo $this->translate('groupname') ?>:</label>
                         <input class="formfield" type="text" name="name" id="name" value="<?php echo $this->escape($this->group_details['name']) ?>" size=35/>
                     </li>
                 </ul>
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
                 </div>
             </fieldset>
         </form>

--- a/extensions/ki_adminpanel/templates/scripts/floaters/editstatus.php
+++ b/extensions/ki_adminpanel/templates/scripts/floaters/editstatus.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['editstatus'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('editstatus') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="floater_content">
@@ -12,17 +12,17 @@
             <fieldset>
                 <ul>
                     <li>
-                        <label for="status"><?php echo $this->kga['lang']['status'] ?>:</label>
+                        <label for="status"><?php echo $this->translate('status') ?>:</label>
                         <input class="formfield" type="text" name="status" id="status" value="<?php echo $this->escape($this->status_details['status']) ?>" size=35/>
                     </li>
                     <li>
-                        <label for="default"><?php echo $this->kga['lang']['default'] ?>:</label>
+                        <label for="default"><?php echo $this->translate('default') ?>:</label>
                         <input class="formfield" type="checkbox" name="default" id="status" value="1" <?php if ($this->status_details['statusID'] == $this->kga->getDefaultStatus()) echo 'checked="checked"' ?>/>
                     </li>
                 </ul>
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
                 </div>
             </fieldset>
         </form>

--- a/extensions/ki_adminpanel/templates/scripts/floaters/edituser.php
+++ b/extensions/ki_adminpanel/templates/scripts/floaters/edituser.php
@@ -1,20 +1,20 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['editUser'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('editUser') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#groupstab">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['groups'] ?></span>
+                    <span class="bb"><?php echo $this->translate('groups') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -26,38 +26,38 @@
             <fieldset id="general">
                 <ul>
                     <li>
-                        <label for="name"><?php echo $this->kga['lang']['username'] ?>:</label>
+                        <label for="name"><?php echo $this->translate('username') ?>:</label>
                         <input class="formfield" type="text" id="name" name="name" value="<?php echo $this->escape($this->user_details['name']) ?>" maxlength=20 size=20/>
                     </li>
                     <li>
-                        <label for="globalRoleID"><?php echo $this->kga['lang']['globalRole'] ?>:</label>
+                        <label for="globalRoleID"><?php echo $this->translate('globalRole') ?>:</label>
                         <?php echo $this->formSelect('globalRoleID', $this->user_details['globalRoleID'], [
                             'class' => 'formfield'
                         ], $this->globalRoles); ?>
                     </li>
                     <li>
-                        <label for="password"><?php echo $this->kga['lang']['newPassword'] ?>:</label>
-                        <input class="formfield" type="password" name="password" size="9" id="password"/> <?php echo $this->kga['lang']['minLength'] ?>
+                        <label for="password"><?php echo $this->translate('newPassword') ?>:</label>
+                        <input class="formfield" type="password" name="password" size="9" id="password"/> <?php echo $this->translate('minLength') ?>
                         <?php if ($this->user_details['password'] == ""): ?>
                             <br/>
                             <img src="<?php echo $this->skin('grfx/caution_mini.png'); ?>" alt="Caution" valign="middle"/>
-                            <strong style="color:red"><?php echo $this->kga['lang']['nopasswordset'] ?></strong>
+                            <strong style="color:red"><?php echo $this->translate('nopasswordset') ?></strong>
                         <?php endif; ?>
                     </li>
                     <li>
-                        <label for="retypePassword"><?php echo $this->kga['lang']['retypePassword'] ?>:</label>
+                        <label for="retypePassword"><?php echo $this->translate('retypePassword') ?>:</label>
                         <input class="formfield" type="password" name="retypePassword" id="retypePassword" size="9"/>
                     </li>
                     <li>
-                        <label for="rate"><?php echo $this->kga['lang']['rate'] ?>:</label>
+                        <label for="rate"><?php echo $this->translate('rate') ?>:</label>
                         <input class="formfield" type="text" id="rate" name="rate" value="<?php echo $this->escape(str_replace('.', $this->kga['conf']['decimalSeparator'], $this->user_details['rate'])); ?>"/>
                     </li>
                     <li>
-                        <label for="mail"><?php echo $this->kga['lang']['mail'] ?>:</label>
+                        <label for="mail"><?php echo $this->translate('mail') ?>:</label>
                         <input class="formfield" type="text" id="mail" name="mail" value="<?php echo $this->escape($this->user_details['mail']) ?>"/>
                     </li>
                     <li>
-                        <label for="alias"><?php echo $this->kga['lang']['alias'] ?>:</label>
+                        <label for="alias"><?php echo $this->translate('alias') ?>:</label>
                         <input class="formfield" type="text" id="alias" name="alias" value="<?php echo $this->escape($this->user_details['alias']) ?>"/>
                     </li>
                 </ul>
@@ -65,8 +65,8 @@
             <fieldset id="groupstab">
                 <table class="groupsTable">
                     <tr>
-                        <td><label><?php echo $this->kga['lang']['groups'] ?>:</label></td>
-                        <td><label><?php echo $this->kga['lang']['membershipRole'] ?>:</label></td>
+                        <td><label><?php echo $this->translate('groups') ?>:</label></td>
+                        <td><label><?php echo $this->translate('membershipRole') ?>:</label></td>
                     </tr>
                     <?php
 
@@ -106,8 +106,8 @@
                 </table>
             </fieldset>
             <div id="formbuttons">
-                <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	            <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	            <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
             </div>
         </form>
     </div>
@@ -168,7 +168,7 @@
         var memberships = <?php echo json_encode($this->membershipRoles); ?>;
 
         $('#adminPanel_extension_form_editUser').ajaxForm(options);
-        
+
         function deleteButtonClicked() {
             var row = $(this).parent().parent()[0];
             var id = $('#groupsTable', row).val();

--- a/extensions/ki_adminpanel/templates/scripts/globalRoles.php
+++ b/extensions/ki_adminpanel/templates/scripts/globalRoles.php
@@ -1,14 +1,14 @@
 <form>
     <input type="text" id="newGlobalRole" class="formfield" />
-    <input class='btn_ok' type=submit value="<?php echo $this->kga['lang']['addGlobalRole'] ?>" onclick="adminPanel_extension_newGlobalRole(); return false;">
+    <input class='btn_ok' type=submit value="<?php echo $this->translate('addGlobalRole') ?>" onclick="adminPanel_extension_newGlobalRole(); return false;">
 </form>
 <br/>
 <table>
     <thead>
     <tr class='headerrow'>
-        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
-        <th width="25%"><?php echo $this->kga['lang']['globalRole'] ?></th>
-        <th><?php echo $this->kga['lang']['users'] ?></th>
+        <th width="80px"><?php echo $this->translate('options') ?></th>
+        <th width="25%"><?php echo $this->translate('globalRole') ?></th>
+        <th><?php echo $this->translate('users') ?></th>
     </tr>
     </thead>
     <tbody>
@@ -16,7 +16,7 @@
     if (count($this->globalRoles) == 0) {
         ?>
         <tr>
-            <td nowrap colspan='3'>
+            <td nowrap colspan="3">
                 <?php echo $this->error(); ?>
             </td>
         </tr>
@@ -27,14 +27,14 @@
             <tr class='<?php echo $this->cycle(["odd", "even"])->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editGlobalRole('<?php echo $globalRole['globalRoleID'] ?>'); $(this).blur(); return false;">
-                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editGlobalRole'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->translate('editGlobalRole') ?>" width="13" height="13" alt="<?php echo $this->translate('editGlobalRole') ?>" border="0"></a>
                     &nbsp;
                     <?php if ($globalRole['count_users'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteGlobalRole(<?php echo $globalRole['globalRoleID'] ?>)"><img
                                 src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>"
-                                title="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" border="0"></a>
+                                title="<?php echo $this->translate('deleteGlobalRole') ?>" width="13" height="13" alt="<?php echo $this->translate('deleteGlobalRole') ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteGlobalRole'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->translate('deleteGlobalRole') ?>" width="13" height="13" alt="<?php echo $this->translate('deleteGlobalRole') ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/groups.php
+++ b/extensions/ki_adminpanel/templates/scripts/groups.php
@@ -1,14 +1,14 @@
 <form>
     <input type="text" id="newgroup" class="formfield" />
-    <input class='btn_ok' type=submit value="<?php echo $this->kga['lang']['addgroup'] ?>" onclick="adminPanel_extension_newGroup(); return false;">
+    <input class='btn_ok' type=submit value="<?php echo $this->translate('addgroup') ?>" onclick="adminPanel_extension_newGroup(); return false;">
 </form>
 <br/>
 <table>
     <thead>
     <tr class='headerrow'>
-        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
-        <th width="25%"><?php echo $this->kga['lang']['group'] ?></th>
-        <th><?php echo $this->kga['lang']['members'] ?></th>
+        <th width="80px"><?php echo $this->translate('options') ?></th>
+        <th width="25%"><?php echo $this->translate('group') ?></th>
+        <th><?php echo $this->translate('members') ?></th>
     </tr>
     </thead>
     <tbody>
@@ -16,7 +16,7 @@
     if (!isset($this->groups) || $this->groups == '0' || count($this->groups) == 0) {
         ?>
         <tr>
-            <td nowrap colspan='3'>
+            <td nowrap colspan="3">
                 <?php echo $this->error(); ?>
             </td>
         </tr>
@@ -27,14 +27,14 @@
             <tr class='<?php echo $this->cycle(["odd", "even"])->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editGroup('<?php echo $grouparray['groupID'] ?>'); $(this).blur(); return false;">
-                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editGroup'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editGroup'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->translate('editGroup') ?>" width="13" height="13" alt="<?php echo $this->translate('editGroup') ?>" border="0"></a>
                     &nbsp;
                     <?php if ($grouparray['count_users'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteGroup(<?php echo $grouparray['groupID'] ?>)"><img
                                 src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>"
-                                title="<?php echo $this->kga['lang']['delete_group'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_group'] ?>" border="0"></a>
+                                title="<?php echo $this->translate('delete_group') ?>" width="13" height="13" alt="<?php echo $this->translate('delete_group') ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['delete_group'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_group'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->translate('delete_group') ?>" width="13" height="13" alt="<?php echo $this->translate('delete_group') ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/membershipRoles.php
+++ b/extensions/ki_adminpanel/templates/scripts/membershipRoles.php
@@ -1,14 +1,14 @@
 <form>
     <input type="text" id="newMembershipRole" class="formfield"/>
-    <input class='btn_ok' type=submit value="<?php echo $this->kga['lang']['addMembershipRole'] ?>" onclick="adminPanel_extension_newMembershipRole(); return false;">
+    <input class='btn_ok' type=submit value="<?php echo $this->translate('addMembershipRole') ?>" onclick="adminPanel_extension_newMembershipRole(); return false;">
 </form>
 <br/>
 <table>
     <thead>
     <tr class='headerrow'>
-        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
-        <th width="25%"><?php echo $this->kga['lang']['membershipRole'] ?></th>
-        <th><?php echo $this->kga['lang']['users'] ?></th>
+        <th width="80px"><?php echo $this->translate('options') ?></th>
+        <th width="25%"><?php echo $this->translate('membershipRole') ?></th>
+        <th><?php echo $this->translate('users') ?></th>
     </tr>
     </thead>
     <tbody>
@@ -16,7 +16,7 @@
     if (count($this->membershipRoles) == 0) {
         ?>
         <tr>
-            <td nowrap colspan='3'>
+            <td nowrap colspan="3">
                 <?php echo $this->error(); ?>
             </td>
         </tr>
@@ -27,14 +27,14 @@
             <tr class='<?php echo $this->cycle(["odd", "even"])->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editMembershipRole('<?php echo $membershipRole['membershipRoleID'] ?>'); $(this).blur(); return false;">
-                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editMembershipRole'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->translate('editMembershipRole') ?>" width="13" height="13" alt="<?php echo $this->translate('editMembershipRole') ?>" border="0"></a>
                     &nbsp;
                     <?php if ($membershipRole['count_users'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteMembershipRole(<?php echo $membershipRole['membershipRoleID'] ?>)"><img
                                 src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>"
-                                title="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" border="0"></a>
+                                title="<?php echo $this->translate('deleteMembershipRole') ?>" width="13" height="13" alt="<?php echo $this->translate('deleteMembershipRole') ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteMembershipRole'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->translate('deleteMembershipRole') ?>" width="13" height="13" alt="<?php echo $this->translate('deleteMembershipRole') ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>

--- a/extensions/ki_adminpanel/templates/scripts/projects.php
+++ b/extensions/ki_adminpanel/templates/scripts/projects.php
@@ -1,44 +1,40 @@
-<a href="#" onclick="floaterShow('floaters.php', 'add_edit_project', 0, 0, 650); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->kga['lang']['new_project']?>"></a>
-<?php echo $this->kga['lang']['new_project']?><br/><br/>
+<a href="#" onclick="floaterShow('floaters.php', 'add_edit_project', 0, 0, 650); $(this).blur(); return false;"><img src="<?php echo $this->skin('grfx/add.png'); ?>" width="22" height="16" alt="<?php echo $this->translate('new_project')?>"></a>
+<?php echo $this->translate('new_project')?><br/><br/>
 <table>
 <thead>
 	<tr class="headerrow">
-		<th width="80px"><?php echo $this->kga['lang']['options']?></th>
+		<th width="80px"><?php echo $this->translate('options')?></th>
 		<?php if ($this->kga->getSettings()->isFlipProjectDisplay()): ?>
-			<th width="25%"><?php echo $this->kga['lang']['customer']?></th>
-			<th><?php echo $this->kga['lang']['project']?></th>
+			<th width="25%"><?php echo $this->translate('customer')?></th>
+			<th><?php echo $this->translate('project')?></th>
 		<?php else: ?>
-			<th width="25%"><?php echo $this->kga['lang']['project']?></th>
-			<th><?php echo $this->kga['lang']['customer']?></th>
+			<th width="25%"><?php echo $this->translate('project')?></th>
+			<th><?php echo $this->translate('customer')?></th>
 		<?php endif; ?>
-		<th width="25%"><?php echo $this->kga['lang']['groups']?></th>
+		<th width="25%"><?php echo $this->translate('groups')?></th>
 	</tr>
 </thead>
 <tbody>
 <?php
-	if (!isset($this->projects) || $this->projects == '0' || count($this->projects) == 0) 
-	{
+	if (!isset($this->projects) || $this->projects == '0' || count($this->projects) == 0) {
 		?>
 		<tr>
 			<td nowrap colspan="3"><?php echo $this->error(); ?></td>
 		</tr>
 		<?php
-	} 
-	else 
-	{
-		foreach ($this->projects as $row) 
-		{
+	} else {
+		foreach ($this->projects as $row) {
 			$isHidden = $row['visible'] != 1 || $row['customerVisible'] != 1;
 			?>
 			<tr class="<?php echo $this->cycle(["odd", "even"])->next()?>">
 				<td class="option">
 					<a href="#" onclick="editSubject('project',<?php echo $row['projectID']?>); $(this).blur(); return false;"><img
 						src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13"
-						alt="<?php echo $this->kga['lang']['edit']?>" title="<?php echo $this->kga['lang']['edit']?>" border="0" /></a>
+						alt="<?php echo $this->translate('edit')?>" title="<?php echo $this->translate('edit')?>" border="0" /></a>
 					&nbsp;
 					<a href="#" id="delete_project<?php echo $row['projectID']?>" onclick="adminPanel_extension_deleteProject(<?php echo $row['projectID']?>)"><img
-						src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_project']?>"
-						width="13" height="13" alt="<?php echo $this->kga['lang']['delete_project']?>" border="0"></a>
+						src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->translate('delete_project')?>"
+						width="13" height="13" alt="<?php echo $this->translate('delete_project')?>" border="0"></a>
 				</td>
 				<?php if ($this->kga->getSettings()->isFlipProjectDisplay()): ?>
 					<td class="customer <?php if ($isHidden) { echo 'hidden'; } ?>">

--- a/extensions/ki_adminpanel/templates/scripts/status.php
+++ b/extensions/ki_adminpanel/templates/scripts/status.php
@@ -1,14 +1,14 @@
 <form>
     <input type="text" id="newstatus" class="formfield"/>
-    <input class='btn_ok' type=submit value="<?php echo $this->kga['lang']['new_status'] ?>" onclick="adminPanel_extension_newStatus(); return false;">
+    <input class='btn_ok' type=submit value="<?php echo $this->translate('new_status') ?>" onclick="adminPanel_extension_newStatus(); return false;">
 </form>
 <br/>
 <table>
     <thead>
     <tr class='headerrow'>
-        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
-        <th width="25%"><?php echo $this->kga['lang']['status'] ?></th>
-        <th><?php echo $this->kga['lang']['default'] ?></th>
+        <th width="80px"><?php echo $this->translate('options') ?></th>
+        <th width="25%"><?php echo $this->translate('status') ?></th>
+        <th><?php echo $this->translate('default') ?></th>
     </tr>
     </thead>
     <tbody>
@@ -16,7 +16,7 @@
     if (!isset($this->statuses) || $this->statuses == '0' || count($this->statuses) == 0) {
         ?>
         <tr>
-            <td nowrap colspan='3'>
+            <td nowrap colspan="3">
                 <?php echo $this->error(); ?>
             </td>
         </tr>
@@ -27,22 +27,22 @@
             <tr class='<?php echo $this->cycle(["odd", "even"])->next() ?>'>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editStatus('<?php echo $statusarray['statusID'] ?>'); $(this).blur(); return false;"><img
-                            src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editstatus'] ?>"
-                            width="13" height="13" alt="<?php echo $this->kga['lang']['editstatus'] ?>" border="0"></a>
+                            src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->translate('editstatus') ?>"
+                            width="13" height="13" alt="<?php echo $this->translate('editstatus') ?>" border="0"></a>
                     &nbsp;
                     <?php if ($statusarray['timeSheetEntryCount'] == 0): ?>
                         <a href="#" onclick="adminPanel_extension_deleteStatus(<?php echo $statusarray['statusID'] ?>)"><img
-                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['delete_status'] ?>"
-                                width="13" height="13" alt="<?php echo $this->kga['lang']['delete_status'] ?>" border="0"></a>
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->translate('delete_status') ?>"
+                                width="13" height="13" alt="<?php echo $this->translate('delete_status') ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['delete_status'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['delete_status'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->translate('delete_status') ?>" width="13" height="13" alt="<?php echo $this->translate('delete_status') ?>" border="0">
                     <?php endif; ?>
                 </td>
                 <td>
                     <?php echo $this->escape($statusarray['status']) ?>
                 </td>
                 <td>
-                    <?php echo $statusarray['statusID'] == $this->kga->getDefaultStatus() ? $this->kga['lang']['default'] : '' ?>
+                    <?php echo $statusarray['statusID'] == $this->kga->getDefaultStatus() ? $this->translate('default') : '' ?>
                 </td>
             </tr>
             <?php

--- a/extensions/ki_adminpanel/templates/scripts/users.php
+++ b/extensions/ki_adminpanel/templates/scripts/users.php
@@ -1,21 +1,21 @@
 <form>
     <input type="text" id="newuser" class="formfield"/>
-    <input class='btn_ok' type="submit" value="<?php echo $this->kga['lang']['adduser'] ?>" onclick="adminPanel_extension_newUser(); return false;">
+    <input class='btn_ok' type="submit" value="<?php echo $this->translate('adduser') ?>" onclick="adminPanel_extension_newUser(); return false;">
     <?php if ($this->showDeletedUsers): ?>
-        <input class='btn_ok' type="button" value="<?php echo $this->kga['lang']['hidedeletedusers'] ?>" onclick="adminPanel_extension_hideDeletedUsers(); return false;">
+        <input class='btn_ok' type="button" value="<?php echo $this->translate('hidedeletedusers') ?>" onclick="adminPanel_extension_hideDeletedUsers(); return false;">
     <?php else: ?>
-        <input class='btn_ok' type="button" value="<?php echo $this->kga['lang']['showdeletedusers'] ?>" onclick="adminPanel_extension_showDeletedUsers(); return false;">
+        <input class='btn_ok' type="button" value="<?php echo $this->translate('showdeletedusers') ?>" onclick="adminPanel_extension_showDeletedUsers(); return false;">
     <?php endif; ?>
 </form>
 <br/>
 <table>
     <thead>
     <tr>
-        <th width="80px"><?php echo $this->kga['lang']['options'] ?></th>
-        <th width="25%"><?php echo $this->kga['lang']['username'] ?></th>
-        <th><?php echo $this->kga['lang']['status'] ?></th>
-        <th><?php echo $this->kga['lang']['globalRole'] ?></th>
-        <th width="25%"><?php echo $this->kga['lang']['groups']?></th>
+        <th width="80px"><?php echo $this->translate('options') ?></th>
+        <th width="25%"><?php echo $this->translate('username') ?></th>
+        <th><?php echo $this->translate('status') ?></th>
+        <th><?php echo $this->translate('globalRole') ?></th>
+        <th width="25%"><?php echo $this->translate('groups')?></th>
     </tr>
     </thead>
     <tbody>
@@ -23,7 +23,7 @@
     if (!isset($this->users) || $this->users == '0' || count($this->users) == 0) {
         ?>
         <tr>
-            <td nowrap colspan='4'>
+            <td nowrap colspan="4">
                 <?php echo $this->error(); ?>
             </td>
         </tr>
@@ -35,22 +35,22 @@
                 <?php /* ########## Option cells ########## */ ?>
                 <td class="option">
                     <a href="#" onclick="adminPanel_extension_editUser('<?php echo $userarray['userID'] ?>'); $(this).blur(); return false;">
-                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->kga['lang']['editUser'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['editUser'] ?>" border="0"></a>
+                        <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" title="<?php echo $this->translate('editUser') ?>" width="13" height="13" alt="<?php echo $this->translate('editUser') ?>" border="0"></a>
                     &nbsp;
                     <?php if ($userarray['mail']): ?>
                         <a href="mailto:<?php echo $this->escape($userarray['mail']); ?>"><img
                                 src="<?php echo $this->skin('grfx/button_mail.gif'); ?>"
-                                title="<?php echo $this->kga['lang']['mailUser'] ?>" width="12" height="13" alt="<?php echo $this->kga['lang']['mailUser'] ?>" border="0"></a>
+                                title="<?php echo $this->translate('mailUser') ?>" width="12" height="13" alt="<?php echo $this->translate('mailUser') ?>" border="0"></a>
                     <?php else: ?>
-                        <img src="<?php echo $this->skin('grfx/button_mail_.gif'); ?>" title="<?php echo $this->kga['lang']['mailUser'] ?>" width="12" height="13" alt="<?php echo $this->kga['lang']['mailUser'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_mail_.gif'); ?>" title="<?php echo $this->translate('mailUser') ?>" width="12" height="13" alt="<?php echo $this->translate('mailUser') ?>" border="0">
                     <?php endif; ?>
                     &nbsp;
                     <?php if ($this->curr_user != $userarray['name']) { ?>
                         <a href="#" id="deleteUser<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_deleteUser(<?php echo $userarray['userID'] ?>, <?php echo($userarray['trash'] ? "2" : "1"); ?>)"><img
-                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['deleteUser'] ?>"
-                                width="13" height="13" alt="<?php echo $this->kga['lang']['deleteUser'] ?>" border="0"></a>
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->translate('deleteUser') ?>"
+                                width="13" height="13" alt="<?php echo $this->translate('deleteUser') ?>" border="0"></a>
                     <?php } else { ?>
-                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->kga['lang']['deleteUser'] ?>" width="13" height="13" alt="<?php echo $this->kga['lang']['deleteUser'] ?>" border="0">
+                        <img src="<?php echo $this->skin('grfx/button_trashcan_.png'); ?>" title="<?php echo $this->translate('deleteUser') ?>" width="13" height="13" alt="<?php echo $this->translate('deleteUser') ?>" border="0">
                     <?php } ?>
                 </td>
 
@@ -70,26 +70,26 @@
                     <?php if ($userarray['active'] == 1): ?>
                         <?php if ($this->curr_user != $userarray['name']): ?>
                             <a href="#" id="ban<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_banUser('<?php echo $userarray['userID'] ?>'); return false;">
-                                <img src="<?php echo $this->skin('grfx/jipp.gif'); ?>" alt='<?php echo $this->kga['lang']['activeAccount'] ?>' title='<?php echo $this->kga['lang']['activeAccount'] ?>' border="0" width="16" height="16"/></a>
+                                <img src="<?php echo $this->skin('grfx/jipp.gif'); ?>" alt='<?php echo $this->translate('activeAccount') ?>' title='<?php echo $this->translate('activeAccount') ?>' border="0" width="16" height="16"/></a>
                         <?php else: ?>
-                            <img src="<?php echo $this->skin('grfx/jipp_.gif'); ?>" alt='<?php echo $this->kga['lang']['activeAccount'] ?>' title='<?php echo $this->kga['lang']['activeAccount'] ?>' border="0" width="16" height="16"/>
+                            <img src="<?php echo $this->skin('grfx/jipp_.gif'); ?>" alt='<?php echo $this->translate('activeAccount') ?>' title='<?php echo $this->translate('activeAccount') ?>' border="0" width="16" height="16"/>
                         <?php endif; ?>
                     <?php endif; ?>
 
                     <?php if ($userarray['active'] == 0): ?>
                         <a href="#" id="ban<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_unbanUser('<?php echo $userarray['userID'] ?>'); return false;">
-                            <img src="<?php echo $this->skin('grfx/lock.png'); ?>" alt='<?php echo $this->kga['lang']['bannedUser'] ?>' title='<?php echo $this->kga['lang']['bannedUser'] ?>' border="0" width="16" height="16"/></a>
+                            <img src="<?php echo $this->skin('grfx/lock.png'); ?>" alt='<?php echo $this->translate('bannedUser') ?>' title='<?php echo $this->translate('bannedUser') ?>' border="0" width="16" height="16"/></a>
                     <?php endif; ?>
                     &nbsp;
                     <?php if ($userarray['passwordSet'] == "no"): ?>
                         <a href="#" onclick="adminPanel_extension_editUser('<?php echo $userarray['userID'] ?>'); $(this).blur(); return false;">
-                            <img src="<?php echo $this->skin('grfx/caution_mini.png'); ?>" width="16" height="16" title='<?php echo $this->kga['lang']['nopasswordset'] ?>' border="0"></a>
+                            <img src="<?php echo $this->skin('grfx/caution_mini.png'); ?>" width="16" height="16" title='<?php echo $this->translate('nopasswordset') ?>' border="0"></a>
                     <?php endif; ?>
                     &nbsp;
                     <?php if ($userarray['trash']): ?>
                         <a href="#" id="deleteUser<?php echo $userarray['userID'] ?>" onclick="adminPanel_extension_deleteUser(<?php echo $userarray['userID'] ?>, 0)"><img
-                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->kga['lang']['restoreAccount'] ?>"
-                                width="13" height="13" alt="<?php echo $this->kga['lang']['restoreAccount'] ?>" border="0"></a>
+                                src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" title="<?php echo $this->translate('restoreAccount') ?>"
+                                width="13" height="13" alt="<?php echo $this->translate('restoreAccount') ?>" border="0"></a>
                     <?php endif; ?>
                 </td>
                 <!-- ########## /Status cells ########## -->
@@ -111,6 +111,6 @@
     </tbody>
 </table>
 <p>
-    <strong><?php echo $this->kga['lang']['hint'] ?></strong> <?php echo $this->kga['lang']['rename_caution_before_username'] ?>
-    '<?php echo $this->escape($this->curr_user) ?>' <?php echo $this->kga['lang']['rename_caution_after_username'] ?>
+    <strong><?php echo $this->translate('hint') ?></strong> <?php echo $this->translate('rename_caution_before_username') ?>
+    '<?php echo $this->escape($this->curr_user) ?>' <?php echo $this->translate('rename_caution_after_username') ?>
 </p>

--- a/extensions/ki_budget/templates/scripts/charts.php
+++ b/extensions/ki_budget/templates/scripts/charts.php
@@ -33,7 +33,7 @@ foreach ($this->projects as $project)
             if ($projectPlotData['budget'] - $projectPlotData['budget'] < 0) {
                 ?>
                 <tr>
-                    <td class="budgetminus"><?php echo $this->kga['lang']['budget_minus'] ?>:</td>
+                    <td class="budgetminus"><?php echo $this->translate('budget_minus') ?>:</td>
                     <td><?php
                         $budget = $projectPlotData['budget'];
                         $total = $projectPlotData['total'];
@@ -77,7 +77,7 @@ foreach ($this->projects as $project)
                 {
                     ?>
                     <tr>
-                        <td class="budgetminus"><?php echo $this->kga['lang']['budget_minus'] ?>:</td>
+                        <td class="budgetminus"><?php echo $this->translate('budget_minus') ?>:</td>
                         <td><?php
                             $budget = $activity['budget_total'];
                             $total = $activity['total'];

--- a/extensions/ki_expenses/templates/scripts/expenses.php
+++ b/extensions/ki_expenses/templates/scripts/expenses.php
@@ -43,12 +43,12 @@ if ($this->expenses)
             <td nowrap class="option <?php echo $tdClass ?>">
 
             <?php if (isset($this->kga['user']) && (!$this->kga->isEditLimit() || time() - $row['timestamp'] <= $this->kga->getEditLimit())): ?>
-                <a href ='#' onclick="expense_editRecord(<?php echo $row['expenseID']?>); $(this).blur(); return false;" title='<?php echo $this->kga['lang']['edit']?>'>
-                <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border='0' /></a>
+                <a href ='#' onclick="expense_editRecord(<?php echo $row['expenseID']?>); $(this).blur(); return false;" title='<?php echo $this->translate('edit')?>'>
+                <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13" alt='<?php echo $this->translate('edit')?>' title='<?php echo $this->translate('edit')?>' border="0" /></a>
 
                 <?php if ($this->kga->getSettings()->isShowQuickDelete()): ?>
                     <a href ='#' class='quickdelete' onclick="expense_quickdelete(<?php echo $row['expenseID']?>); return false;">
-                    <img src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" width='13' height='13' alt='<?php echo $this->kga['lang']['quickdelete']?>' title='<?php echo $this->kga['lang']['quickdelete']?>' border=0 />
+                    <img src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" width="13" height="13" alt='<?php echo $this->translate('quickdelete')?>' title='<?php echo $this->translate('quickdelete')?>' border=0 />
                     </a>
                 <?php endif; ?>
             <?php endif; ?>
@@ -68,7 +68,7 @@ if ($this->expenses)
             </td>
 
             <td class="refundable <?php echo $tdClass ?>">
-                    <?php echo $row['refundable'] ? $this->kga['lang']['yes'] : $this->kga['lang']['no'] ?>
+                    <?php echo $row['refundable'] ? $this->translate('yes') : $this->translate('no') ?>
             </td>
 
             <td class="customer <?php echo $tdClass ?>">

--- a/extensions/ki_expenses/templates/scripts/floaters/add_edit_record.php
+++ b/extensions/ki_expenses/templates/scripts/floaters/add_edit_record.php
@@ -5,31 +5,31 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
     <div id="floater_handle">
         <span id="floater_title"><?php
             if (isset($this->id)) {
-                echo $this->kga['lang']['edit'];
+                echo $this->translate('edit');
             } else {
-                echo $this->kga['lang']['add'];
+                echo $this->translate('add');
             }
         ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
-            <a href="#" class="help" onclick="$(this).blur(); $('#help').slideToggle();"><?php echo $this->kga['lang']['help'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
+            <a href="#" class="help" onclick="$(this).blur(); $('#help').slideToggle();"><?php echo $this->translate('help') ?></a>
         </div>
     </div>
     <div id="help">
         <div class="content">
-            <?php echo $this->kga['lang']['dateAndTimeHelp'] ?>
+            <?php echo $this->translate('dateAndTimeHelp') ?>
         </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#extended">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['advanced'] ?></span>
+                    <span class="bb"><?php echo $this->translate('advanced') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -41,7 +41,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
             <fieldset id="general">
                 <ul>
                     <li>
-                        <label for="projectID"><?php echo $this->kga['lang']['project'] ?>:</label>
+                        <label for="projectID"><?php echo $this->translate('project') ?>:</label>
                         <div class="multiFields">
                             <?php
                             echo $this->formSelect('projectID', $this->selected_project, [
@@ -57,52 +57,52 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         </div>
                     </li>
                     <li>
-                        <label for="edit_day"><?php echo $this->kga['lang']['day'] ?>:</label>
-                        <input id='edit_day' type='text' name='edit_day' value='<?php echo $this->escape($this->edit_day) ?>' maxlength='10' size='10' tabindex='5' <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                        <label for="edit_day"><?php echo $this->translate('day') ?>:</label>
+                        <input id='edit_day' type='text' name='edit_day' value='<?php echo $this->escape($this->edit_day) ?>' maxlength="10" size="10" tabindex="5" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                     </li>
                     <li>
-                        <label for="edit_time"><?php echo $this->kga['lang']['timelabel'] ?>:</label>
-                        <input id='edit_time' type='text' name='edit_time' value='<?php echo $this->escape($this->edit_time) ?>' maxlength='8' size='8' tabindex='7' <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
-                        <a href="#" onclick="expense_pasteNow(); $(this).blur(); return false;"><?php echo $this->kga['lang']['now'] ?></a>
+                        <label for="edit_time"><?php echo $this->translate('timelabel') ?>:</label>
+                        <input id='edit_time' type='text' name='edit_time' value='<?php echo $this->escape($this->edit_time) ?>' maxlength="8" size="8" tabindex="7" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                        <a href="#" onclick="expense_pasteNow(); $(this).blur(); return false;"><?php echo $this->translate('now') ?></a>
                     </li>
                     <li>
-                        <label for="multiplier"><?php echo $this->kga['lang']['multiplier'] ?>:</label>
-                        <input id='multiplier' type='text' name='multiplier' value='<?php echo $this->escape($this->multiplier) ?>' maxlength='8' size='8' tabindex='9' <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                        <label for="multiplier"><?php echo $this->translate('multiplier') ?>:</label>
+                        <input id="multiplier" type="text" name="multiplier" value="<?php echo $this->escape($this->multiplier) ?>" maxlength="8" size="8" tabindex="9" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                     </li>
                     <li>
-                        <label for="edit_value"><?php echo $this->kga['lang']['expense'] ?>:</label>
-                        <input id='edit_value' type='text' name='edit_value' value='<?php echo $this->escape($this->edit_value) ?>' maxlength='8' size='8' tabindex='10' <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                        <label for="edit_value"><?php echo $this->translate('expense') ?>:</label>
+                        <input id="edit_value" type="text" name="edit_value" value="<?php echo $this->escape($this->edit_value) ?>" maxlength="8" size="8" tabindex="10" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                     </li>
                     <li>
-                        <label for="designation"><?php echo $this->kga['lang']['designation'] ?>:</label>
-                        <input id='designation' type='text' name='designation' value='<?php echo $this->escape($this->designation) ?>' maxlength='50' size='50' tabindex='11' <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
+                        <label for="designation"><?php echo $this->translate('designation') ?>:</label>
+                        <input id="designation" type="text" name="designation" value="<?php echo $this->escape($this->designation) ?>" maxlength="50" size="50" tabindex="11" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                     </li>
                 </ul>
             </fieldset>
             <fieldset id="extended">
                 <ul>
                     <li>
-                        <label for="refundable"><?php echo $this->kga['lang']['refundable_long'] ?>:</label>
-                        <input type='checkbox' id='refundable' name='refundable' <?php if ($this->refundable): ?> checked="checked" <?php endif; ?> tabindex='12'/>
+                        <label for="refundable"><?php echo $this->translate('refundable_long') ?>:</label>
+                        <input type="checkbox" id="refundable" name="refundable" <?php if ($this->refundable): ?> checked="checked" <?php endif; ?> tabindex="12"/>
                     </li>
                     <li>
-                        <label for="comment"><?php echo $this->kga['lang']['comment'] ?>:</label>
-                        <textarea id='comment' style="width:395px" class='comment' name='comment' cols='40' rows='5' tabindex='13'><?php echo $this->escape($this->comment) ?></textarea>
+                        <label for="comment"><?php echo $this->translate('comment') ?>:</label>
+                        <textarea id="comment" style="width:395px" class="comment" name="comment" cols="40" rows="5" tabindex="13"><?php echo $this->escape($this->comment) ?></textarea>
                     </li>
                     <li>
-                        <label for="commentType"><?php echo $this->kga['lang']['commentType'] ?>:</label>
+                        <label for="commentType"><?php echo $this->translate('commentType') ?>:</label>
                         <?php echo $this->commentTypeSelect($this->commentType); ?>
                     </li>
                     <li>
-                        <label for="erase"><?php echo $this->kga['lang']['erase'] ?>:</label>
-                        <input type='checkbox' id='erase' name='erase' tabindex='15'/>
+                        <label for="erase"><?php echo $this->translate('erase') ?>:</label>
+                        <input type="checkbox" id="erase" name="erase" tabindex="15"/>
                     </li>
                 </ul>
             </fieldset>
         </div>
         <div id="formbuttons">
-            <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-            <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	        <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	        <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>
@@ -116,7 +116,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
             var $self = $(this);
             $self.val($self.val().replace(/,/g, '.'));
         });
-        
+
         var $expense_extension_form_add_edit_record = $('#expense_extension_form_add_edit_record');
         $expense_extension_form_add_edit_record.ajaxForm({
             'beforeSubmit': function () {

--- a/extensions/ki_expenses/templates/scripts/main.php
+++ b/extensions/ki_expenses/templates/scripts/main.php
@@ -1,7 +1,7 @@
 <div id="expenses_head">
     <div class="left">
         <?php if (isset($this->kga['user'])): ?>
-            <a href="#" onclick="floaterShow('../extensions/ki_expenses/floaters.php','add_edit_record',0,0,600); $(this).blur(); return false;"><?php echo $this->kga['lang']['add'] ?></a>
+            <a href="#" onclick="floaterShow('../extensions/ki_expenses/floaters.php','add_edit_record',0,0,600); $(this).blur(); return false;"><?php echo $this->translate('add') ?></a>
         <?php endif; ?>
     </div>
     <table>
@@ -19,14 +19,14 @@
         <tbody>
         <tr>
             <td class="option">&nbsp;</td>
-            <td class="date"><?php echo $this->kga['lang']['datum'] ?></td>
-            <td class="time"><?php echo $this->kga['lang']['timelabel'] ?></td>
-            <td class="value"><?php echo $this->kga['lang']['expense'] ?></td>
-            <td class="refundable"><?php echo $this->kga['lang']['refundable'] ?></td>
-            <td class="customer"><?php echo $this->kga['lang']['customer'] ?></td>
-            <td class="project"><?php echo $this->kga['lang']['project'] ?></td>
-            <td class="designation"><?php echo $this->kga['lang']['designation'] ?></td>
-            <td class="username"><?php echo $this->kga['lang']['username'] ?></td>
+            <td class="date"><?php echo $this->translate('datum') ?></td>
+            <td class="time"><?php echo $this->translate('timelabel') ?></td>
+            <td class="value"><?php echo $this->translate('expense') ?></td>
+            <td class="refundable"><?php echo $this->translate('refundable') ?></td>
+            <td class="customer"><?php echo $this->translate('customer') ?></td>
+            <td class="project"><?php echo $this->translate('project') ?></td>
+            <td class="designation"><?php echo $this->translate('designation') ?></td>
+            <td class="username"><?php echo $this->translate('username') ?></td>
         </tr>
         </tbody>
     </table>

--- a/extensions/ki_export/templates/scripts/floaters/export_CSV.php
+++ b/extensions/ki_export/templates/scripts/floaters/export_CSV.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['export_extension']['exportCSV'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('export_extension:exportCSV') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div id="help">
@@ -25,24 +25,24 @@
             <fieldset>
                 <ul>
                     <li>
-                        <label for="column_delimiter"><?php echo $this->kga['lang']['export_extension']['column_delimiter'] ?>:</label>
+                        <label for="column_delimiter"><?php echo $this->translate('export_extension:column_delimiter') ?>:</label>
                         <input type="text" value="<?php echo $this->escape($this->prefs['column_delimiter']) ?>" name="column_delimiter" id="column_delimiter" size="1"/>
                     </li>
                     <li>
-                        <label for="quote_char"><?php echo $this->kga['lang']['export_extension']['quote_char'] ?>:</label>
+                        <label for="quote_char"><?php echo $this->translate('export_extension:quote_char') ?>:</label>
                         <input type="text" value="<?php echo $this->escape($this->prefs['quote_char']) ?>" name="quote_char" id="quote_char" size="1">
                     </li>
                     <li>
-                        <label for="reverse_order"><?php echo $this->kga['lang']['export_extension']['reverse_order'] ?>:</label>
+                        <label for="reverse_order"><?php echo $this->translate('export_extension:reverse_order') ?>:</label>
                         <input type="checkbox" value="true" name="reverse_order" id="reverse_order"/>
                     </li>
                     <li>
-                        <?php echo $this->kga['lang']['export_extension']['dl_hint'] ?>
+                        <?php echo $this->translate('export_extension:dl_hint') ?>
                     </li>
                 </ul>
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>' onclick="floaterClose();"/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>" onclick="floaterClose();"/>
                 </div>
             </fieldset>
         </form>

--- a/extensions/ki_export/templates/scripts/floaters/export_PDF.php
+++ b/extensions/ki_export/templates/scripts/floaters/export_PDF.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['export_extension']['exportPDF'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('export_extension:exportPDF') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div id="help">
@@ -24,54 +24,54 @@
             <fieldset>
                 <ul>
                     <li>
-                        <label for="print_comments"><?php echo $this->kga['lang']['export_extension']['print_comment'] ?>:</label>
+                        <label for="print_comments"><?php echo $this->translate('export_extension:print_comment') ?>:</label>
                         <input type="checkbox" value="true" name="print_comments" id="print_comments" <?php if ($this->prefs['print_comments']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                     <li>
-                        <label for="print_summary"><?php echo $this->kga['lang']['export_extension']['print_summary'] ?>:</label>
+                        <label for="print_summary"><?php echo $this->translate('export_extension:print_summary') ?>:</label>
                         <input type="checkbox" value="true" name="print_summary" id="print_summary" <?php if ($this->prefs['print_summary']): ?> checked="checked" <?php endif; ?>>
                     </li>
                     <li>
-                        <label for="create_bookmarks"><?php echo $this->kga['lang']['export_extension']['create_bookmarks'] ?>:</label>
+                        <label for="create_bookmarks"><?php echo $this->translate('export_extension:create_bookmarks') ?>:</label>
                         <input type="checkbox" value="true" name="create_bookmarks" id="create_bookmarks" <?php if ($this->prefs['create_bookmarks']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                     <li>
-                        <label for="download_pdf"><?php echo $this->kga['lang']['export_extension']['download_pdf'] ?>:</label>
+                        <label for="download_pdf"><?php echo $this->translate('export_extension:download_pdf') ?>:</label>
                         <input type="checkbox" value="true" name="download_pdf" id="download_pdf" <?php if ($this->prefs['download_pdf']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                     <li>
-                        <label for="customer_new_page"><?php echo $this->kga['lang']['export_extension']['customer_new_page'] ?>:</label>
+                        <label for="customer_new_page"><?php echo $this->translate('export_extension:customer_new_page') ?>:</label>
                         <input type="checkbox" value="true" name="customer_new_page" id="customer_new_page" <?php if ($this->prefs['customer_new_page']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                     <li>
-                        <label for="reverse_order"><?php echo $this->kga['lang']['export_extension']['reverse_order'] ?>:</label>
+                        <label for="reverse_order"><?php echo $this->translate('export_extension:reverse_order') ?>:</label>
                         <input type="checkbox" value="true" name="reverse_order" id="reverse_order" <?php if ($this->prefs['reverse_order']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                     <li>
-                        <label for="time_type"><?php echo $this->kga['lang']['export_extension']['time_type']?>:</label>
+                        <label for="time_type"><?php echo $this->translate('export_extension:time_type')?>:</label>
                         <select name="time_type" id="time_type">
-                            <option value="dec_time" <?php if ($this->prefs['time_type'] == 'dec_time'): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['export_extension']['dec_time'] ?></option>
-                            <option value="time" <?php if ($this->prefs['time_type'] == 'time'): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['export_extension']['time'] ?></option>
-                        </select>    
-                    </li>
-                    <li>
-                        <label for="document_comment"><?php echo $this->kga['lang']['comment'] ?>:</label>
-                        <textarea name="document_comment" id="document_comment"></textarea>
-                    </li>
-                    <li>
-                        <label for="axAction"><?php echo $this->kga['lang']['export_extension']['pdf_format'] ?>:</label>
-                        <select name="axAction" id="axAction">
-                            <option value="export_pdf" <?php if ($this->prefs['pdf_format'] == 'export_pdf'): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['export_extension']['export_pdf'] ?></option>
-                            <option value="export_pdf2" <?php if ($this->prefs['pdf_format'] == 'export_pdf2'): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['export_extension']['export_pdf2'] ?></option>
+                            <option value="dec_time" <?php if ($this->prefs['time_type'] == 'dec_time'): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('export_extension:dec_time') ?></option>
+                            <option value="time" <?php if ($this->prefs['time_type'] == 'time'): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('export_extension:time') ?></option>
                         </select>
                     </li>
                     <li>
-                        <?php echo $this->kga['lang']['export_extension']['dl_hint'] ?>
+                        <label for="document_comment"><?php echo $this->translate('comment') ?>:</label>
+                        <textarea name="document_comment" id="document_comment"></textarea>
+                    </li>
+                    <li>
+                        <label for="axAction"><?php echo $this->translate('export_extension:pdf_format') ?>:</label>
+                        <select name="axAction" id="axAction">
+                            <option value="export_pdf" <?php if ($this->prefs['pdf_format'] == 'export_pdf'): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('export_extension:export_pdf') ?></option>
+                            <option value="export_pdf2" <?php if ($this->prefs['pdf_format'] == 'export_pdf2'): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('export_extension:export_pdf2') ?></option>
+                        </select>
+                    </li>
+                    <li>
+                        <?php echo $this->translate('export_extension:dl_hint') ?>
                     </li>
                 </ul>
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>' onclick="floaterClose();"/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>" onclick="floaterClose();"/>
                 </div>
             </fieldset>
         </form>

--- a/extensions/ki_export/templates/scripts/floaters/export_XLS.php
+++ b/extensions/ki_export/templates/scripts/floaters/export_XLS.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['export_extension']['exportXLS'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('export_extension:exportXLS') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div id="help">
@@ -24,16 +24,16 @@
             <fieldset>
                 <ul>
                     <li>
-                        <label for="reverse_order"><?php echo $this->kga['lang']['export_extension']['reverse_order'] ?>:</label>
+                        <label for="reverse_order"><?php echo $this->translate('export_extension:reverse_order') ?>:</label>
                         <input type="checkbox" value="true" name="reverse_order" id="reverse_order" <?php if ($this->prefs['reverse_order']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                     <li>
-                        <?php echo $this->kga['lang']['export_extension']['dl_hint'] ?>
+                        <?php echo $this->translate('export_extension:dl_hint') ?>
                     </li>
                 </ul>
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>' onclick="floaterClose();"/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>" onclick="floaterClose();"/>
                 </div>
             </fieldset>
         </form>

--- a/extensions/ki_export/templates/scripts/floaters/help_timeformat.php
+++ b/extensions/ki_export/templates/scripts/floaters/help_timeformat.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['export_extension']['export_timeformat_help'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('export_extension:export_timeformat_help') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="floater_content">

--- a/extensions/ki_export/templates/scripts/floaters/print.php
+++ b/extensions/ki_export/templates/scripts/floaters/print.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['export_extension']['print'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('export_extension:print') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div id="help">
@@ -24,20 +24,20 @@
             <fieldset>
                 <ul>
                     <li>
-                        <?php echo $this->kga['lang']['export_extension']['print_hint'] ?>
+                        <?php echo $this->translate('export_extension:print_hint') ?>
                     </li>
                     <li>
-                        <label for="print_summary"><?php echo $this->kga['lang']['export_extension']['print_summary'] ?>:</label>
+                        <label for="print_summary"><?php echo $this->translate('export_extension:print_summary') ?>:</label>
                         <input type="checkbox" value="true" name="print_summary" id="print_summary" <?php if ($this->prefs['print_summary']): ?> checked="checked" <?php endif; ?>>
                     </li>
                     <li>
-                        <label for="reverse_order"><?php echo $this->kga['lang']['export_extension']['reverse_order'] ?>:</label>
+                        <label for="reverse_order"><?php echo $this->translate('export_extension:reverse_order') ?>:</label>
                         <input type="checkbox" value="true" name="reverse_order" id="reverse_order" <?php if ($this->prefs['reverse_order']): ?> checked="checked" <?php endif; ?>/>
                     </li>
                 </ul>
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>' onclick="floaterClose();"/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>" onclick="floaterClose();"/>
                 </div>
             </fieldset>
         </form>

--- a/extensions/ki_export/templates/scripts/formats/html.php
+++ b/extensions/ki_export/templates/scripts/formats/html.php
@@ -1,8 +1,6 @@
 <html>
   <head>
     <title></title>
-    <meta content="">
-    
 	<style type="text/css" media="all">
 		body, div, dl, dt, dd, ul, ol, li, h1, h2, h3, h4, h5, h6, pre, form, fieldset, input, textarea, p, blockquote, th, td {
 		  margin: 0;
@@ -45,11 +43,10 @@
 		  font-weight: bold;
 		  margin-bottom: 10px;
 		}
-		
 	</style>
-		
+
 	<style type="text/css" media="print">
-		
+
 		body {
 			color: black;
 			font-family: Arial, Verdana, sans-serif;
@@ -75,14 +72,10 @@
 			display: none;
 		}
 
-		#div_liste {
-
-		}
-
 		#invertbtn, .invertclm {
 			display: none;
 		}
-		
+
 	</style>
 
 	<style type="text/css" media="screen">
@@ -118,35 +111,35 @@
   </head>
   <body>
 
-<h2> <?php echo $this->kga['lang']['export_extension']['time_period']?>: <?php echo $this->escape($this->timespan) ?></h2>
+<h2><?php echo $this->translate('export_extension:time_period')?>: <?php echo $this->escape($this->timespan) ?></h2>
 
 <?php if ($this->customersFilter != ""): ?>
-<br/><b><?php echo $this->kga['lang']['customers']?></b>: <?php echo $this->escape($this->customersFilter) ?>
-<?php endif; 
+<br/><b><?php echo $this->translate('customers')?></b>: <?php echo $this->escape($this->customersFilter) ?>
+<?php endif;
 if ($this->projectsFilter != ""): ?>
-<br/><b><?php echo $this->kga['lang']['projects']?></b>: <?php echo $this->escape($this->projectsFilter) ?>
+<br/><b><?php echo $this->translate('projects')?></b>: <?php echo $this->escape($this->projectsFilter) ?>
 <?php endif; ?>
 <br/>
 
 <?php if ($this->summary != 0): ?>
-  <h2><?php echo $this->kga['lang']['export_extension']['summary']?></h2>
+  <h2><?php echo $this->translate('export_extension:summary')?></h2>
 
 
   <table border="1">
     <tbody>
       <tr>
-        <th><?php echo $this->kga['lang']['activity']?></th>
+        <th><?php echo $this->translate('activity')?></th>
   <?php if (isset($this->columns['dec_time'])): ?>
-        <th><?php echo $this->kga['lang']['export_extension']['duration']?></th>
+        <th><?php echo $this->translate('export_extension:duration')?></th>
   <?php endif; ?>
   <?php if (isset($this->columns['wage'])): ?>
-        <th><?php echo $this->kga['lang']['export_extension']['costs']?></th>
+        <th><?php echo $this->translate('export_extension:costs')?></th>
   <?php endif; ?>
   <?php if (isset($this->columns['budget'])): ?>
-        <th><?php echo $this->kga['lang']['budget']?></th>
+        <th><?php echo $this->translate('budget')?></th>
   <?php endif; ?>
   <?php if (isset($this->columns['approved'])): ?>
-        <th><?php echo $this->kga['lang']['approved']?></th>
+        <th><?php echo $this->translate('approved')?></th>
   <?php endif; ?>
       </tr>
 
@@ -170,7 +163,7 @@ if ($this->projectsFilter != ""): ?>
 
       <tr>
         <td>
-          <i><?php echo $this->kga['lang']['export_extension']['finalamount']?></i>
+          <i><?php echo $this->translate('export_extension:finalamount')?></i>
         </td>
   <?php if (isset($this->columns['dec_time'])): ?>
         <td><?php echo $this->escape(number_format($this->timeSum, 2, $this->kga['conf']['decimalSeparator'], ""))?></td>
@@ -190,40 +183,40 @@ if ($this->projectsFilter != ""): ?>
   </table>
 <?php endif; ?>
 
-<h2><?php echo $this->kga['lang']['export_extension']['full_list']?></h2>
+<h2><?php echo $this->translate('export_extension:full_list')?></h2>
 
           <table border="1">
             <tbody>
 
                 <tr>
-<?php if (isset($this->columns['date'])):         ?> <th><?php echo $this->kga['lang']['datum']?></th>       <?php endif; ?>
-<?php if (isset($this->columns['from'])):         ?> <th><?php echo $this->kga['lang']['in']?></th>          <?php endif; ?>
-<?php if (isset($this->columns['to'])):           ?> <th><?php echo $this->kga['lang']['out']?></th>         <?php endif; ?>
-<?php if (isset($this->columns['time'])):         ?> <th><?php echo $this->kga['lang']['time']?></th>        <?php endif; ?>
-<?php if (isset($this->columns['dec_time'])):     ?> <th><?php echo $this->kga['lang']['timelabel']?></th>   <?php endif; ?>
-<?php if (isset($this->columns['rate'])):         ?> <th><?php echo $this->kga['lang']['rate']?></th>        <?php endif; ?>
+<?php if (isset($this->columns['date'])):         ?> <th><?php echo $this->translate('datum')?></th>       <?php endif; ?>
+<?php if (isset($this->columns['from'])):         ?> <th><?php echo $this->translate('in')?></th>          <?php endif; ?>
+<?php if (isset($this->columns['to'])):           ?> <th><?php echo $this->translate('out')?></th>         <?php endif; ?>
+<?php if (isset($this->columns['time'])):         ?> <th><?php echo $this->translate('time')?></th>        <?php endif; ?>
+<?php if (isset($this->columns['dec_time'])):     ?> <th><?php echo $this->translate('timelabel')?></th>   <?php endif; ?>
+<?php if (isset($this->columns['rate'])):         ?> <th><?php echo $this->translate('rate')?></th>        <?php endif; ?>
 <?php if (isset($this->columns['wage'])):         ?> <th><?php echo $this->kga->getCurrencyName()?></th>       <?php endif; ?>
-<?php if (isset($this->columns['budget'])):       ?> <th><?php echo $this->kga['lang']['budget']?></th>      <?php endif; ?>
-<?php if (isset($this->columns['approved'])):     ?> <th><?php echo $this->kga['lang']['approved']?></th>    <?php endif; ?>
-<?php if (isset($this->columns['status'])):       ?> <th><?php echo $this->kga['lang']['status']?></th>      <?php endif; ?>
-<?php if (isset($this->columns['billable'])):     ?> <th><?php echo $this->kga['lang']['billable']?></th>    <?php endif; ?>
-<?php if (isset($this->columns['customer'])):     ?> <th><?php echo $this->kga['lang']['customer']?></th>    <?php endif; ?>
-<?php if (isset($this->columns['project'])):      ?> <th><?php echo $this->kga['lang']['project']?></th>     <?php endif; ?>
-<?php if (isset($this->columns['activity'])):     ?> <th><?php echo $this->kga['lang']['activity']?></th>    <?php endif; ?>
-<?php if (isset($this->columns['description'])):  ?> <th><?php echo $this->kga['lang']['description']?></th> <?php endif; ?>
-<?php if (isset($this->columns['comment'])):      ?> <th><?php echo $this->kga['lang']['comment']?></th>     <?php endif; ?>
-<?php if (isset($this->columns['location'])):     ?> <th><?php echo $this->kga['lang']['location']?></th>   <?php endif; ?>
-<?php if (isset($this->columns['trackingNumber'])):   ?> <th><?php echo $this->kga['lang']['trackingNumber']?></th>  <?php endif; ?>
-<?php if (isset($this->columns['user'])):         ?> <th><?php echo $this->kga['lang']['username']?></th>    <?php endif; ?>
-<?php if (isset($this->columns['cleared'])):      ?> <th><?php echo $this->kga['lang']['cleared']?></th>     <?php endif; ?>
+<?php if (isset($this->columns['budget'])):       ?> <th><?php echo $this->translate('budget')?></th>      <?php endif; ?>
+<?php if (isset($this->columns['approved'])):     ?> <th><?php echo $this->translate('approved')?></th>    <?php endif; ?>
+<?php if (isset($this->columns['status'])):       ?> <th><?php echo $this->translate('status')?></th>      <?php endif; ?>
+<?php if (isset($this->columns['billable'])):     ?> <th><?php echo $this->translate('billable')?></th>    <?php endif; ?>
+<?php if (isset($this->columns['customer'])):     ?> <th><?php echo $this->translate('customer')?></th>    <?php endif; ?>
+<?php if (isset($this->columns['project'])):      ?> <th><?php echo $this->translate('project')?></th>     <?php endif; ?>
+<?php if (isset($this->columns['activity'])):     ?> <th><?php echo $this->translate('activity')?></th>    <?php endif; ?>
+<?php if (isset($this->columns['description'])):  ?> <th><?php echo $this->translate('description')?></th> <?php endif; ?>
+<?php if (isset($this->columns['comment'])):      ?> <th><?php echo $this->translate('comment')?></th>     <?php endif; ?>
+<?php if (isset($this->columns['location'])):     ?> <th><?php echo $this->translate('location')?></th>   <?php endif; ?>
+<?php if (isset($this->columns['trackingNumber'])):   ?> <th><?php echo $this->translate('trackingNumber')?></th>  <?php endif; ?>
+<?php if (isset($this->columns['user'])):         ?> <th><?php echo $this->translate('username')?></th>    <?php endif; ?>
+<?php if (isset($this->columns['cleared'])):      ?> <th><?php echo $this->translate('cleared')?></th>     <?php endif; ?>
 
                 </tr>
-               
+
 <?php foreach ($this->exportData as $row): ?>
 
-    
+
                 <tr>
-    
+
 
 <?php if (isset($this->columns['date'])): ?>
                     <td>
@@ -249,14 +242,14 @@ if ($this->projectsFilter != ""): ?>
 
 <?php if (isset($this->columns['to'])): ?>
                     <td>
-                    
+
 <?php if ($row['time_out']): ?>
                         <?php  if ($this->custom_timeformat)
                             echo $this->escape(strftime($this->custom_timeformat,$row['time_out']));
                           else
                             echo $this->escape(strftime("%H:%M", $row['time_in']));
                         ?>
-<?php else: ?>      
+<?php else: ?>
                         &ndash;&ndash;:&ndash;&ndash;
 <?php endif; ?>
                     </td>
@@ -335,7 +328,7 @@ if ($this->projectsFilter != ""): ?>
 
 <?php if (isset($this->columns['activity'])): ?>
                     <td>
-                            <?php echo $this->escape($row['activityName']); ?> 
+                            <?php echo $this->escape($row['activityName']); ?>
                     </td>
 <?php endif; ?>
 
@@ -357,7 +350,7 @@ if ($this->projectsFilter != ""): ?>
 <?php if (isset($this->columns['location'])): ?>
                     <td>
                         <?php echo $this->escape($row['location']); ?>
-                        
+
                     </td>
 <?php endif; ?>
 
@@ -365,7 +358,7 @@ if ($this->projectsFilter != ""): ?>
 <?php if (isset($this->columns['trackingNumber'])): ?>
                     <td>
                         <?php echo $this->escape($row['trackingNumber']); ?>
-                        
+
                     </td>
 <?php endif; ?>
 
@@ -373,26 +366,26 @@ if ($this->projectsFilter != ""): ?>
 <?php if (isset($this->columns['user'])): ?>
                     <td>
                         <?php echo $this->escape($row['username']); ?>
-                        
+
                     </td>
 <?php endif; ?>
 
 
 <?php if (isset($this->columns['cleared'])): ?>
 					<td>
-                      <?php if ($row['cleared']) echo $this->kga['lang']['cleared']?>
+                      <?php if ($row['cleared']) echo $this->translate('cleared')?>
 					</td>
 <?php endif; ?>
-					
+
 
                 </tr>
-               
+
 <?php endforeach; ?>
 
 <?php if ($this->timeSum > 0 || $this->wageSum > 0): ?>
 <tr>
 <td colspan="<?php echo count($this->columns)?>">
-<?php echo $this->kga['lang']['export_extension']['finalamount']?>
+<?php echo $this->translate('export_extension:finalamount')?>
 </td>
 </tr>
 <tr>
@@ -424,7 +417,7 @@ if ($this->projectsFilter != ""): ?>
   <?php if (isset($this->columns['cleared'])): ?> <td></td> <?php endif; ?>
 </tr>
 <?php endif; ?>
-            </tbody>   
+            </tbody>
         </table>
 </body>
 </html>

--- a/extensions/ki_export/templates/scripts/main.php
+++ b/extensions/ki_export/templates/scripts/main.php
@@ -3,61 +3,61 @@
         <tbody>
         <tr>
             <td class="date <?php if (isset($this->disabled_columns['date'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('date');" title="<?php echo $this->kga['lang']['datum'] ?>"><?php echo $this->ellipsis($this->kga['lang']['datum'], 5) ?></a>
+                <a onclick="export_toggle_column('date');" title="<?php echo $this->translate('datum') ?>"><?php echo $this->ellipsis($this->translate('datum'), 5) ?></a>
             </td>
             <td class="from <?php if (isset($this->disabled_columns['from'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('from');" title="<?php echo $this->kga['lang']['in'] ?>"><?php echo $this->ellipsis($this->kga['lang']['in'], 5) ?></a>
+                <a onclick="export_toggle_column('from');" title="<?php echo $this->translate('in') ?>"><?php echo $this->ellipsis($this->translate('in'), 5) ?></a>
             </td>
             <td class="to <?php if (isset($this->disabled_columns['to'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('to');" title="<?php echo $this->kga['lang']['out'] ?>"><?php echo $this->ellipsis($this->kga['lang']['out'], 5) ?></a>
+                <a onclick="export_toggle_column('to');" title="<?php echo $this->translate('out') ?>"><?php echo $this->ellipsis($this->translate('out'), 5) ?></a>
             </td>
             <td class="time <?php if (isset($this->disabled_columns['time'])):?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('time');" title="<?php echo $this->kga['lang']['time'] ?>"><?php echo $this->ellipsis($this->kga['lang']['time'], 4) ?></a>
+                <a onclick="export_toggle_column('time');" title="<?php echo $this->translate('time') ?>"><?php echo $this->ellipsis($this->translate('time'), 4) ?></a>
             </td>
             <td class="dec_time <?php if (isset($this->disabled_columns['dec_time'])):?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('dec_time');" title="<?php echo $this->kga['lang']['timelabel'] ?>"><?php echo $this->ellipsis($this->kga['lang']['timelabel'], 4) ?></a>
+                <a onclick="export_toggle_column('dec_time');" title="<?php echo $this->translate('timelabel') ?>"><?php echo $this->ellipsis($this->translate('timelabel'), 4) ?></a>
             </td>
             <td class="rate <?php if (isset($this->disabled_columns['rate'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('rate');" title="<?php echo $this->kga['lang']['rate_short'] ?>"><?php echo $this->ellipsis($this->kga['lang']['rate_short'], 5) ?></a>
+                <a onclick="export_toggle_column('rate');" title="<?php echo $this->translate('rate_short') ?>"><?php echo $this->ellipsis($this->translate('rate_short'), 5) ?></a>
             </td>
             <td class="wage <?php if (isset($this->disabled_columns['wage'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('wage');" title="<?php echo $this->kga['lang']['total'] ?>"><?php echo $this->ellipsis($this->kga['lang']['total'], 5) ?></a>
+                <a onclick="export_toggle_column('wage');" title="<?php echo $this->translate('total') ?>"><?php echo $this->ellipsis($this->translate('total'), 5) ?></a>
             </td>
             <td class="budget <?php if (isset($this->disabled_columns['budget'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('budget');" title="<?php echo $this->kga['lang']['budget'] ?>"><?php echo $this->ellipsis($this->kga['lang']['budget'], 5) ?></a>
+                <a onclick="export_toggle_column('budget');" title="<?php echo $this->translate('budget') ?>"><?php echo $this->ellipsis($this->translate('budget'), 5) ?></a>
             </td>
             <td class="approved <?php if (isset($this->disabled_columns['approved'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('approved');" title="<?php echo $this->kga['lang']['approved'] ?>"><?php echo $this->ellipsis($this->kga['lang']['approved'], 4) ?></a>
+                <a onclick="export_toggle_column('approved');" title="<?php echo $this->translate('approved') ?>"><?php echo $this->ellipsis($this->translate('approved'), 4) ?></a>
             </td>
             <td class="status <?php if (isset($this->disabled_columns['status'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('status');" title="<?php echo $this->kga['lang']['status'] ?>"><?php echo $this->ellipsis($this->kga['lang']['status'], 4) ?></a>
+                <a onclick="export_toggle_column('status');" title="<?php echo $this->translate('status') ?>"><?php echo $this->ellipsis($this->translate('status'), 4) ?></a>
             </td>
             <td class="billable <?php if (isset($this->disabled_columns['billable'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('billable');" title="<?php echo $this->kga['lang']['billable'] ?>"><?php echo $this->ellipsis($this->kga['lang']['billable'], 3) ?></a>
+                <a onclick="export_toggle_column('billable');" title="<?php echo $this->translate('billable') ?>"><?php echo $this->ellipsis($this->translate('billable'), 3) ?></a>
             </td>
             <td class="customer <?php if (isset($this->disabled_columns['customer'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('customer');" title="<?php echo $this->kga['lang']['customer'] ?>"><?php echo $this->ellipsis($this->kga['lang']['customer'], 12) ?></a>
+                <a onclick="export_toggle_column('customer');" title="<?php echo $this->translate('customer') ?>"><?php echo $this->ellipsis($this->translate('customer'), 12) ?></a>
             </td>
             <td class="project <?php if (isset($this->disabled_columns['project'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('project');" title="<?php echo $this->kga['lang']['project'] ?>"><?php echo $this->ellipsis($this->kga['lang']['project'], 8) ?></a>
+                <a onclick="export_toggle_column('project');" title="<?php echo $this->translate('project') ?>"><?php echo $this->ellipsis($this->translate('project'), 8) ?></a>
             </td>
             <td class="activity <?php if (isset($this->disabled_columns['activity'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('activity');" title="<?php echo $this->kga['lang']['activity'] ?>"><?php echo $this->ellipsis($this->kga['lang']['activity'], 21) ?></a>
+                <a onclick="export_toggle_column('activity');" title="<?php echo $this->translate('activity') ?>"><?php echo $this->ellipsis($this->translate('activity'), 21) ?></a>
             </td>
             <td class="description <?php if (isset($this->disabled_columns['description'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('description');" title="<?php echo $this->kga['lang']['description'] ?>"><?php echo $this->ellipsis($this->kga['lang']['description'], 13) ?></a>
+                <a onclick="export_toggle_column('description');" title="<?php echo $this->translate('description') ?>"><?php echo $this->ellipsis($this->translate('description'), 13) ?></a>
             </td>
             <td class="comment <?php if (isset($this->disabled_columns['comment'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('comment');" title="<?php echo $this->kga['lang']['comment'] ?>"><?php echo $this->ellipsis($this->kga['lang']['comment'], 3) ?></a>
+                <a onclick="export_toggle_column('comment');" title="<?php echo $this->translate('comment') ?>"><?php echo $this->ellipsis($this->translate('comment'), 3) ?></a>
             </td>
             <td class="location <?php if (isset($this->disabled_columns['location'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('location');" title="<?php echo $this->kga['lang']['location'] ?>"><?php echo $this->ellipsis($this->kga['lang']['location'], 3) ?></a>
+                <a onclick="export_toggle_column('location');" title="<?php echo $this->translate('location') ?>"><?php echo $this->ellipsis($this->translate('location'), 3) ?></a>
             </td>
             <td class="trackingNumber <?php if (isset($this->disabled_columns['trackingNumber'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('trackingNumber');" title="<?php echo $this->kga['lang']['trackingNumber'] ?>"><?php echo $this->ellipsis($this->kga['lang']['trackingNumber'], 3) ?></a>
+                <a onclick="export_toggle_column('trackingNumber');" title="<?php echo $this->translate('trackingNumber') ?>"><?php echo $this->ellipsis($this->translate('trackingNumber'), 3) ?></a>
             </td>
             <td class="user <?php if (isset($this->disabled_columns['user'])): ?>disabled<?php endif; ?>">
-                <a onclick="export_toggle_column('user');" title="<?php echo $this->kga['lang']['username'] ?>"><?php echo $this->ellipsis($this->kga['lang']['username'], 4) ?></a>
+                <a onclick="export_toggle_column('user');" title="<?php echo $this->translate('username') ?>"><?php echo $this->ellipsis($this->translate('username'), 4) ?></a>
             </td>
             <td class="cleared">
                 <a title="<?php echo $this->translate('export_extension:cleared') ?>" onclick="if (export_toogle_cleared_confirm()) { $('#xptable td.cleared>a').click(); } return false;">invert</a>

--- a/extensions/ki_export/templates/scripts/panel.php
+++ b/extensions/ki_export/templates/scripts/panel.php
@@ -5,31 +5,31 @@
                 <div class="c">
                     <div id="export_extension_tab_filter">
                         <select id="export_extension_tab_filter_cleared" name="cleared" onchange="export_extension_reload()">
-                            <option value="-1" <?php if (!$this->kga->getSettings()->isHideClearedEntries()): ?> selected="selected"<?php endif; ?>> <?php echo $this->kga['lang']['export_extension']['cleared_all'] ?></option>
-                            <option value="1"><?php echo $this->kga['lang']['export_extension']['cleared_cleared'] ?></option>
-                            <option value="0" <?php if ($this->kga->getSettings()->isHideClearedEntries()): ?> selected="selected" <?php endif; ?>> <?php echo $this->kga['lang']['export_extension']['cleared_open'] ?></option>
+                            <option value="-1" <?php if (!$this->kga->getSettings()->isHideClearedEntries()): ?> selected="selected"<?php endif; ?>> <?php echo $this->translate('export_extension:cleared_all') ?></option>
+                            <option value="1"><?php echo $this->translate('export_extension:cleared_cleared') ?></option>
+                            <option value="0" <?php if ($this->kga->getSettings()->isHideClearedEntries()): ?> selected="selected" <?php endif; ?>> <?php echo $this->translate('export_extension:cleared_open') ?></option>
                         </select>
                         <select id="export_extension_tab_filter_refundable" name="refundable" onchange="export_extension_reload()">
-                            <option value="-1" selected="selected"><?php echo $this->kga['lang']['export_extension']['refundable_all'] ?></option>
-                            <option value="0"><?php echo $this->kga['lang']['export_extension']['refundable_refundable'] ?></option>
-                            <option value="1"><?php echo $this->kga['lang']['export_extension']['refundable_not_refundable'] ?></option>
+                            <option value="-1" selected="selected"><?php echo $this->translate('export_extension:refundable_all') ?></option>
+                            <option value="0"><?php echo $this->translate('export_extension:refundable_refundable') ?></option>
+                            <option value="1"><?php echo $this->translate('export_extension:refundable_not_refundable') ?></option>
                         </select>
                         <select id="export_extension_tab_filter_type" name="type" onchange="export_extension_reload()">
-                            <option value="-1" selected="selected"><?php echo $this->kga['lang']['export_extension']['times_and_expenses'] ?></option>
-                            <option value="0"><?php echo $this->kga['lang']['export_extension']['times'] ?></option>
-                            <option value="1"><?php echo $this->kga['lang']['export_extension']['expenses'] ?></option>
+                            <option value="-1" selected="selected"><?php echo $this->translate('export_extension:times_and_expenses') ?></option>
+                            <option value="0"><?php echo $this->translate('export_extension:times') ?></option>
+                            <option value="1"><?php echo $this->translate('export_extension:expenses') ?></option>
                         </select>
                     </div>
                     <div id="export_extension_tab_timeformat">
-                        <span><?php echo $this->kga['lang']['export_extension']['timeformat'] ?>
-                            :<a href="#" class="helpfloater"><?php echo $this->kga['lang']['export_extension']['export_timeformat_help'] ?></a></span>
+                        <span><?php echo $this->translate('export_extension:timeformat') ?>
+                            :<a href="#" class="helpfloater"><?php echo $this->translate('export_extension:export_timeformat_help') ?></a></span>
                         <input type="text" name="time_format" value="<?php echo $this->escape($this->timeformat) ?>" id="export_extension_timeformat" onchange="export_extension_reload()">
-                        <span><?php echo $this->kga['lang']['export_extension']['dateformat'] ?>
-                            :<a href="#" class="helpfloater"><?php echo $this->kga['lang']['export_extension']['export_timeformat_help'] ?></a></span>
+                        <span><?php echo $this->translate('export_extension:dateformat') ?>
+                            :<a href="#" class="helpfloater"><?php echo $this->translate('export_extension:export_timeformat_help') ?></a></span>
                         <input type="text" name="date_format" value="<?php echo $this->escape($this->dateformat) ?>" id="export_extension_dateformat" onchange="export_extension_reload()">
                     </div>
                     <div id="export_extension_tab_location">
-                        <span><?php echo $this->kga['lang']['export_extension']['stdrd_location'] ?></span>
+                        <span><?php echo $this->translate('export_extension:stdrd_location') ?></span>
                         <input type="text" name="std_loc" value="" id="export_extension_default_location" onchange="export_extension_reload()">
                     </div>
                 </div>
@@ -41,9 +41,9 @@
     <div class="l">
         <div class="w">
             <div class="c">
-                <a id="export_extension_select_filter" href="#" class="select_btn"><?php echo $this->kga['lang']['filter'] ?></a>
-                <a id="export_extension_select_location" href="#" class="select_btn"><?php echo $this->kga['lang']['export_extension']['stdrd_location'] ?></a>
-                <a id="export_extension_select_timeformat" href="#" class="select_btn"><?php echo $this->kga['lang']['export_extension']['timeformat'] ?></a>
+                <a id="export_extension_select_filter" href="#" class="select_btn"><?php echo $this->translate('filter') ?></a>
+                <a id="export_extension_select_location" href="#" class="select_btn"><?php echo $this->translate('export_extension:stdrd_location') ?></a>
+                <a id="export_extension_select_timeformat" href="#" class="select_btn"><?php echo $this->translate('export_extension:timeformat') ?></a>
             </div>
         </div>
         <div class="l">&nbsp;</div>
@@ -51,10 +51,10 @@
     <div class="r">
         <div class="w">
             <div class="c">
-                <a id="export_extension_export_pdf" href="#" class="output_btn"><?php echo $this->kga['lang']['export_extension']['exportPDF'] ?></a>
-                <a id="export_extension_export_xls" href="#" class="output_btn"><?php echo $this->kga['lang']['export_extension']['exportXLS'] ?></a>
-                <a id="export_extension_export_csv" href="#" class="output_btn"><?php echo $this->kga['lang']['export_extension']['exportCSV'] ?></a>
-                <a id="export_extension_print" href="#" class="output_btn"><?php echo $this->kga['lang']['export_extension']['print'] ?></a>
+                <a id="export_extension_export_pdf" href="#" class="output_btn"><?php echo $this->translate('export_extension:exportPDF') ?></a>
+                <a id="export_extension_export_xls" href="#" class="output_btn"><?php echo $this->translate('export_extension:exportXLS') ?></a>
+                <a id="export_extension_export_csv" href="#" class="output_btn"><?php echo $this->translate('export_extension:exportCSV') ?></a>
+                <a id="export_extension_print" href="#" class="output_btn"><?php echo $this->translate('export_extension:print') ?></a>
             </div>
         </div>
         <div class="l">&nbsp;</div>

--- a/extensions/ki_invoice/templates/scripts/floaters/editVat.php
+++ b/extensions/ki_invoice/templates/scripts/floaters/editVat.php
@@ -1,20 +1,20 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['vat'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('vat') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="floater_content">
         <form id="invoice_extension_editVat" action="../extensions/ki_invoice/processor.php" method="post">
             <input type="hidden" name="axAction" value="editVat"/>
             <fieldset>
-                <label for="vat"><?php echo $this->kga['lang']['vat'] ?></label>
+                <label for="vat"><?php echo $this->translate('vat') ?></label>
                 <input type="number" name="vat" id="vat" value="<?php echo $this->escape(str_replace('.', $this->kga['conf']['decimalSeparator'], $this->kga->getDefaultVat())); ?>" style="width: 50px;"/>
                 %
                 <div id="formbuttons">
-                    <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-                    <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	                <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	                <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
             </fieldset>
         </form>
     </div>

--- a/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
+++ b/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetEntry.php
@@ -5,34 +5,34 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
     <div id="floater_handle">
         <span id="floater_title"><?php
             if (isset($this->id)) {
-                echo $this->kga['lang']['edit'];
+                echo $this->translate('edit');
             } else {
-                echo $this->kga['lang']['add'];
+                echo $this->translate('add');
             }
             ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
-            <a href="#" class="help" onclick="$(this).blur(); $('#help').slideToggle();"><?php echo $this->kga['lang']['help'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
+            <a href="#" class="help" onclick="$(this).blur(); $('#help').slideToggle();"><?php echo $this->translate('help') ?></a>
         </div>
     </div>
     <div id="help">
-        <div class="content"><?php echo $this->kga['lang']['dateAndTimeHelp'] ?></div>
+        <div class="content"><?php echo $this->translate('dateAndTimeHelp') ?></div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#extended">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['advanced'] ?></span>
+                    <span class="bb"><?php echo $this->translate('advanced') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#budget">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['budget'] ?></span>
+                    <span class="bb"><?php echo $this->translate('budget') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -48,7 +48,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
             <fieldset id="general">
                 <ul>
                     <li>
-                        <label for="projectID"><?php echo $this->kga['lang']['project'] ?>:</label>
+                        <label for="projectID"><?php echo $this->translate('project') ?>:</label>
                         <div class="multiFields">
                             <?php echo $this->formSelect('projectID', $this->projectID, [
                                 'size' => '5',
@@ -63,7 +63,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         </div>
                     </li>
                     <li>
-                        <label for="activityID"><?php echo $this->kga['lang']['activity'] ?>:</label>
+                        <label for="activityID"><?php echo $this->translate('activity') ?>:</label>
                         <div class="multiFields">
                             <?php echo $this->formSelect('activityID', $this->activityID, [
                                 'size' => '5',
@@ -78,59 +78,59 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         </div>
                     </li>
                     <li>
-                        <label for="description"><?php echo $this->kga['lang']['description'] ?>:</label>
-                        <textarea tabindex="5" style="width:395px" cols='40' rows='5' name="description" id="description"><?php echo $this->escape($this->description) ?></textarea>
+                        <label for="description"><?php echo $this->translate('description') ?>:</label>
+                        <textarea tabindex="5" style="width:395px" cols="40" rows="5" name="description" id="description"><?php echo $this->escape($this->description) ?></textarea>
                     </li>
                     <li>
-                        <label for="start_day"><?php echo $this->kga['lang']['day'] ?>:</label>
-                        <input id='start_day' type='text' name='start_day' value='<?php echo $this->escape($this->start_day) ?>' maxlength='10' size='10' tabindex='6'
+                        <label for="start_day"><?php echo $this->translate('day') ?>:</label>
+                        <input id="start_day" type="text" name="start_day" value='<?php echo $this->escape($this->start_day) ?>' maxlength="10" size="10" tabindex="6"
                                onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         -
-                        <input id='end_day' type='text' name='end_day' value='<?php echo $this->escape($this->end_day) ?>' maxlength='10' size='10' tabindex='7'
+                        <input id="end_day" type="text" name="end_day" value='<?php echo $this->escape($this->end_day) ?>' maxlength="10" size="10" tabindex="7"
                                onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                     </li>
                     <li>
-                        <label for="start_time"><?php echo $this->kga['lang']['timelabel'] ?>:</label>
-                        <input id='start_time' type='text' name='start_time'
-                               value='<?php echo $this->escape($this->start_time) ?>' maxlength='8' size='8' tabindex='8'
+                        <label for="start_time"><?php echo $this->translate('timelabel') ?>:</label>
+                        <input id="start_time" type="text" name="start_time"
+                               value='<?php echo $this->escape($this->start_time) ?>' maxlength="8" size="8" tabindex="8"
                                onChange="ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
                         -
-                        <input id='end_time' type='text' name='end_time' value='<?php echo $this->escape($this->end_time) ?>' maxlength='8' size='8' tabindex='9'
+                        <input id="end_time" type="text" name="end_time" value='<?php echo $this->escape($this->end_time) ?>' maxlength="8" size="8" tabindex="9"
                                onChange="ts_prefillEndDate(); ts_timeToDuration();" <?php if ($autoSelection): ?> onclick="this.select();" <?php endif; ?> />
-                        <a id="currentTime" href="#" onclick="pasteNow(); ts_timeToDuration(); $(this).blur(); return false;"><?php echo $this->kga['lang']['now'] ?></a>
+                        <a id="currentTime" href="#" onclick="pasteNow(); ts_timeToDuration(); $(this).blur(); return false;"><?php echo $this->translate('now') ?></a>
                     </li>
                     <li>
-                        <label for="duration"><?php echo $this->kga['lang']['durationlabel'] ?>:</label>
-                        <input id='duration' type='text' name='duration' value='' onChange="ts_durationToTime();" maxlength='8' size='8'
-                               tabindex='10' <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
+                        <label for="duration"><?php echo $this->translate('durationlabel') ?>:</label>
+                        <input id="duration" type="text" name="duration" value="" onChange="ts_durationToTime();" maxlength="8" size="8"
+                               tabindex="10" <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
                     </li>
                 </ul>
             </fieldset>
             <fieldset id="extended">
                 <ul>
                     <li>
-                        <label for="location"><?php echo $this->kga['lang']['location'] ?>:</label>
-                        <input id='location' type='text' name='location' value='<?php echo $this->escape($this->location) ?>' maxlength='50' size='20'
-                               tabindex='11' <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
+                        <label for="location"><?php echo $this->translate('location') ?>:</label>
+                        <input id="location" type="text" name="location" value='<?php echo $this->escape($this->location) ?>' maxlength="50" size="20"
+                               tabindex="11" <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
                     </li>
                     <?php if ($this->kga->isTrackingNumberEnabled()): ?>
                         <li>
-                            <label for="trackingNumber"><?php echo $this->kga['lang']['trackingNumber'] ?>:</label>
-                            <input id='trackingNumber' type='text' name='trackingNumber' value='<?php echo $this->escape($this->trackingNumber) ?>' maxlength='20' size='20'
-                                   tabindex='12' <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
+                            <label for="trackingNumber"><?php echo $this->translate('trackingNumber') ?>:</label>
+                            <input id="trackingNumber" type="text" name="trackingNumber" value='<?php echo $this->escape($this->trackingNumber) ?>' maxlength="20" size="20"
+                                   tabindex="12" <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
                         </li>
                     <?php endif; ?>
                     <li>
-                        <label for="comment"><?php echo $this->kga['lang']['comment'] ?>:</label>
-                        <textarea id='comment' style="width:395px" class='comment' name='comment' cols='40' rows='5' tabindex='13'><?php echo $this->escape($this->comment) ?></textarea>
+                        <label for="comment"><?php echo $this->translate('comment') ?>:</label>
+                        <textarea id="comment" style="width:395px" class="comment" name="comment" cols="40" rows="5" tabindex="13"><?php echo $this->escape($this->comment) ?></textarea>
                     </li>
                     <li>
-                        <label for="commentType"><?php echo $this->kga['lang']['commentType'] ?>:</label>
+                        <label for="commentType"><?php echo $this->translate('commentType') ?>:</label>
                         <?php echo $this->commentTypeSelect($this->commentType); ?>
                     </li>
                     <?php if (count($this->users) > 0): ?>
                         <li>
-                            <label for="userID"><?php echo $this->kga['lang']['user'] ?>:</label>
+                            <label for="userID"><?php echo $this->translate('user') ?>:</label>
                             <?php echo $this->formSelect(
                                 isset($this->id) ? 'userID' : 'userID[]',
                                 $this->userID,
@@ -146,29 +146,29 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         <input type="hidden" name="userID" value="<?php echo $this->kga['user']['userID']; ?>"/>
                     <?php endif; ?>
                     <li>
-                        <label for="erase"><?php echo $this->kga['lang']['erase'] ?>:</label>
-                        <input type='checkbox' id='erase' name='erase' tabindex='15'/>
+                        <label for="erase"><?php echo $this->translate('erase') ?>:</label>
+                        <input type="checkbox" id="erase" name="erase" tabindex="15"/>
                     </li>
                     <li>
-                        <label for="cleared"><?php echo $this->kga['lang']['cleared'] ?>:</label>
-                        <input type='checkbox' id='cleared' name='cleared' <?php if ($this->cleared): ?> checked="checked" <?php endif; ?> tabindex='16'/>
+                        <label for="cleared"><?php echo $this->translate('cleared') ?>:</label>
+                        <input type="checkbox" id="cleared" name="cleared" <?php if ($this->cleared): ?> checked="checked" <?php endif; ?> tabindex="16"/>
                     </li>
                 </ul>
             </fieldset>
             <fieldset id="budget">
                 <ul>
                     <li>
-                        <label for="budget_val"><?php echo $this->kga['lang']['budget'] ?>:</label>
-                        <input id='budget_val' type='text' name='budget' value='<?php echo $this->escape($this->budget) ?>' maxlength='50' size='20'
-                               tabindex='11' <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
+                        <label for="budget_val"><?php echo $this->translate('budget') ?>:</label>
+                        <input id="budget_val" type="text" name="budget" value='<?php echo $this->escape($this->budget) ?>' maxlength="50" size="20"
+                               tabindex="11" <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
                     </li>
                     <li>
-                        <label for="approved"><?php echo $this->kga['lang']['approved'] ?>:</label>
-                        <input id='approved' type='text' name='approved' value='<?php echo $this->escape($this->approved) ?>' maxlength='50' size='20'
-                               tabindex='11' <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
+                        <label for="approved"><?php echo $this->translate('approved') ?>:</label>
+                        <input id="approved" type="text" name="approved" value='<?php echo $this->escape($this->approved) ?>' maxlength="50" size="20"
+                               tabindex="11" <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
                     </li>
                     <li>
-                        <label for="statusID"><?php echo $this->kga['lang']['status'] ?>:</label>
+                        <label for="statusID"><?php echo $this->translate('status') ?>:</label>
                         <?php echo $this->formSelect('statusID', $this->statusID, [
                             'id' => 'statusID',
                             'class' => 'formfield',
@@ -176,7 +176,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         ], $this->status); ?>
                     </li>
                     <li>
-                        <label for="billable"><?php echo $this->kga['lang']['billable'] ?>:</label>
+                        <label for="billable"><?php echo $this->translate('billable') ?>:</label>
                         <?php echo $this->formSelect('billable', $this->billable_active, [
                             'id' => 'billable',
                             'class' => 'formfield',
@@ -185,9 +185,9 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                     </li>
                     <?php if ($this->showRate): ?>
                         <li>
-                            <label for="rate"><?php echo $this->kga['lang']['rate'] ?>:</label>
+                            <label for="rate"><?php echo $this->translate('rate') ?>:</label>
                             <input id="rate" type="text" name="rate" value="<?php echo $this->escape($this->rate) ?>" size="5" tabindex="10"/>
-                            <label for="fixedRate" style="float: none; margin-left: 60px;"><?php echo $this->kga['lang']['fixedRate'] ?>:</label>
+                            <label for="fixedRate" style="float: none; margin-left: 60px;"><?php echo $this->translate('fixedRate') ?>:</label>
                             <input id="fixedRate" type="text" name="fixedRate" value="<?php echo $this->escape($this->fixedRate) ?>" size="5"
                                    tabindex="10" <?php if ($autoSelection): ?> onclick="this.select();"<?php endif; ?> />
                         </li>
@@ -195,15 +195,15 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                     <li>
                         <table>
                             <tr>
-                                <td align="right"><?php echo $this->kga['lang']['budget_activity'] ?>:</td>
+                                <td align="right"><?php echo $this->translate('budget_activity') ?>:</td>
                                 <td><span id="budget_activity"><?php echo $this->budget_activity ?></span></td>
                             </tr>
                             <tr>
-                                <td align="right"><?php echo $this->kga['lang']['budget_activity_used'] ?>:</td>
+                                <td align="right"><?php echo $this->translate('budget_activity_used') ?>:</td>
                                 <td><span id="budget_activity_used"><?php echo $this->budget_activity_used ?></span></td>
                             </tr>
                             <tr>
-                                <td align="right"><?php echo $this->kga['lang']['budget_activity_approved'] ?>:</td>
+                                <td align="right"><?php echo $this->translate('budget_activity_approved') ?>:</td>
                                 <td><span id="budget_activity_approved"><?php echo $this->approved_activity ?></span></td>
                             </tr>
                         </table>
@@ -217,8 +217,8 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
             </fieldset>
         </div>
         <div id="formbuttons">
-            <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-            <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	        <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+	        <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>
@@ -380,7 +380,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                 if (!$('#start_day').val().match(ts_dayFormatExp) ||
                     ( !$('#end_day').val().match(ts_dayFormatExp) && $('#end_day').val() != '') || !$('#start_time').val().match(ts_timeFormatExp) ||
                     ( !$('#end_time').val().match(ts_timeFormatExp) && $('#end_time').val() != '')) {
-                    alert("<?php echo $this->kga['lang']['TimeDateInputError']?>");
+                    alert("<?php echo $this->translate('TimeDateInputError')?>");
                     return false;
                 }
 
@@ -408,7 +408,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                     }
 
                     if (inVal > outVal) {
-                        alert("<?php $this->kga['lang']['StartTimeBeforeEndTime']?>");
+                        alert("<?php $this->translate('StartTimeBeforeEndTime')?>");
                         return false;
                     } else if (inVal < outVal) {
                         break;
@@ -440,7 +440,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                         }
 
                         if (inVal > outVal) {
-                            alert("<?php echo $this->kga['lang']['StartTimeBeforeEndTime']?>");
+                            alert("<?php echo $this->translate('StartTimeBeforeEndTime')?>");
                             return false;
                         } else if (inVal < outVal) {
                             break;
@@ -570,8 +570,8 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
         <?php endif; ?>
         var budget = $('#budget_val').val();
         var used = secs / 3600 * rate;
-        var usedString = '<?php echo $this->kga['lang']['used']?>';
-        var budgetString = '<?php echo $this->kga['lang']['budget_available']?>';
+        var usedString = '<?php echo $this->translate('used')?>';
+        var budgetString = '<?php echo $this->translate('budget_available')?>';
         var chartdata = [[usedString, used], [budgetString, budget - used]];
 
         try {
@@ -599,8 +599,7 @@ $autoSelection = $this->kga->getSettings()->isUseAutoSelection();
                     shadow: false
                 }
             });
-        }
-        catch (err) {
+        } catch (err) {
             // probably no data, so remove the chart
             $('#chart').remove();
         }

--- a/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetQuickNote.php
+++ b/extensions/ki_timesheets/templates/scripts/floaters/add_edit_timeSheetQuickNote.php
@@ -2,23 +2,23 @@
     <div id="floater_handle">
 		<span id="floater_title"><?php
             if (isset($this->id)) {
-                echo $this->kga['lang']['editNote'];
+                echo $this->translate('editNote');
             } else {
-                echo $this->kga['lang']['addNote'];
+                echo $this->translate('addNote');
             } ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
-            <a href="#" class="help" onclick="$(this).blur(); $('#help').slideToggle();"><?php echo $this->kga['lang']['help'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
+            <a href="#" class="help" onclick="$(this).blur(); $('#help').slideToggle();"><?php echo $this->translate('help') ?></a>
         </div>
     </div>
     <div id="help">
-        <div class="content"><?php echo $this->kga['lang']['editNoteHelp'] ?></div>
+        <div class="content"><?php echo $this->translate('editNoteHelp') ?></div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#extended">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['note'] ?></span>
+                    <span class="bb"><?php echo $this->translate('note') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -33,34 +33,34 @@
             <fieldset id="extended">
                 <ul>
                     <li>
-                        <label for="location"><?php echo $this->kga['lang']['location'] ?>:</label>
-                        <input id='location' type='text' name='location'
-                               value='<?php echo $this->escape($this->location) ?>' maxlength='50' size='20'
-                               tabindex='11' <?php if ($this->kga->getSettings()->isUseAutoSelection()): ?> onclick="this.select();"<?php endif; ?> />
+                        <label for="location"><?php echo $this->translate('location') ?>:</label>
+                        <input id="location" type="text" name="location"
+                               value='<?php echo $this->escape($this->location) ?>' maxlength="50" size="20"
+                               tabindex="11" <?php if ($this->kga->getSettings()->isUseAutoSelection()): ?> onclick="this.select();"<?php endif; ?> />
                     </li>
                     <?php if ($this->kga->isTrackingNumberEnabled()): ?>
                         <li>
-                            <label for="trackingNumber"><?php echo $this->kga['lang']['trackingNumber'] ?>:</label>
+                            <label for="trackingNumber"><?php echo $this->translate('trackingNumber') ?>:</label>
                             <input id='trackingNumber' type='text' name='trackingNumber'
-                                   value='<?php echo $this->escape($this->trackingNumber) ?>' maxlength='20' size='20'
-                                   tabindex='12' <?php if ($this->kga->getSettings()->isUseAutoSelection()): ?> onclick="this.select();"<?php endif; ?> />
+                                   value='<?php echo $this->escape($this->trackingNumber) ?>' maxlength="20" size="20"
+                                   tabindex="12" <?php if ($this->kga->getSettings()->isUseAutoSelection()): ?> onclick="this.select();"<?php endif; ?> />
                         </li>
                     <?php endif; ?>
                     <li>
-                        <label for="comment"><?php echo $this->kga['lang']['comment'] ?>:</label>
-                        <textarea id='comment' style="width:395px" class='comment' name='comment' cols='40' rows='5'
-                                  tabindex='13'><?php echo $this->escape($this->comment) ?></textarea>
+                        <label for="comment"><?php echo $this->translate('comment') ?>:</label>
+                        <textarea id="comment" style="width:395px" class="comment" name="comment" cols="40" rows="5"
+                                  tabindex="13"><?php echo $this->escape($this->comment) ?></textarea>
                     </li>
                     <li>
-                        <label for="commentType"><?php echo $this->kga['lang']['commentType'] ?>:</label>
+                        <label for="commentType"><?php echo $this->translate('commentType') ?>:</label>
                         <?php echo $this->commentTypeSelect($this->commentType); ?>
                     </li>
                 </ul>
             </fieldset>
         </div>
         <div id="formbuttons">
-            <input class='btn_norm' type='button' value='<?php echo $this->kga['lang']['cancel'] ?>' onclick='floaterClose();return false;'/>
-            <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	        <input type="button" class="btn_norm" value="<?php echo $this->translate('cancel') ?>" onclick="floaterClose();return false;"/>
+	        <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>
@@ -78,7 +78,8 @@
                     $ts_ext_form_add_edit_timeSheetQuickNote.attr('submitting', true);
                     return true;
                 }
-            }, 'success': function (result) {
+            },
+	        'success': function (result) {
                 $ts_ext_form_add_edit_timeSheetQuickNote.removeAttr('submitting');
                 for (var fieldName in result.errors) {
                     setFloaterErrorMessage(fieldName, result.errors[fieldName]);

--- a/extensions/ki_timesheets/templates/scripts/main.php
+++ b/extensions/ki_timesheets/templates/scripts/main.php
@@ -1,7 +1,7 @@
 <div id="timeSheet_head">
     <div class="left">
         <?php if (isset($this->kga['user'])): ?>
-            <a href="#" onclick="floaterShow('../extensions/ki_timesheets/floaters.php','add_edit_timeSheetEntry',selected_project+'|'+selected_activity,0,650); $(this).blur(); return false;"><?php echo $this->kga['lang']['add'] ?></a>
+            <a href="#" onclick="floaterShow('../extensions/ki_timesheets/floaters.php','add_edit_timeSheetEntry',selected_project+'|'+selected_activity,0,650); $(this).blur(); return false;"><?php echo $this->translate('add') ?></a>
         <?php endif; ?>
     </div>
     <table>
@@ -30,25 +30,25 @@
         <tbody>
         <tr>
             <td class="option">&nbsp;</td>
-            <td class="date"><?php echo $this->kga['lang']['datum'] ?></td>
-            <td class="from"><?php echo $this->kga['lang']['in'] ?></td>
-            <td class="to"><?php echo $this->kga['lang']['out'] ?></td>
-            <td class="time"><?php echo $this->kga['lang']['time'] ?></td>
+            <td class="date"><?php echo $this->translate('datum') ?></td>
+            <td class="from"><?php echo $this->translate('in') ?></td>
+            <td class="to"><?php echo $this->translate('out') ?></td>
+            <td class="time"><?php echo $this->translate('time') ?></td>
             <?php if ($this->showBillability) { ?>
-                <td class="billable"><?php echo $this->kga['lang']['billable']?></td>
-                <td class="time_billable"><?php echo $this->kga['lang']['time_billable']?></td>
+                <td class="billable"><?php echo $this->translate('billable')?></td>
+                <td class="time_billable"><?php echo $this->translate('time_billable')?></td>
             <?php } ?>
             <?php if ($this->showRates): ?>
-                <td class="wage"><?php echo $this->kga['lang']['wage'] ?></td>
+                <td class="wage"><?php echo $this->translate('wage') ?></td>
             <?php endif; ?>
-            <td class="customer"><?php echo $this->escape($this->kga['lang']['customer']); ?></td>
-            <td class="project"><?php echo $this->escape($this->kga['lang']['project']); ?></td>
-            <td class="activity"><?php echo $this->escape($this->kga['lang']['activity']); ?></td>
-            <td class="description"><?php echo $this->escape($this->kga['lang']['description']); ?></td>
+            <td class="customer"><?php echo $this->escape($this->translate('customer')); ?></td>
+            <td class="project"><?php echo $this->escape($this->translate('project')); ?></td>
+            <td class="activity"><?php echo $this->escape($this->translate('activity')); ?></td>
+            <td class="description"><?php echo $this->escape($this->translate('description')); ?></td>
             <?php if ($this->showTrackingNumber) { ?>
-                <td class="trackingnumber"><?php echo $this->escape($this->kga['lang']['trackingNumber']); ?></td>
+                <td class="trackingnumber"><?php echo $this->escape($this->translate('trackingNumber')); ?></td>
             <?php } ?>
-            <td class="username"><?php echo $this->escape($this->kga['lang']['username']); ?></td>
+            <td class="username"><?php echo $this->escape($this->translate('username')); ?></td>
         </tr>
         </tbody>
     </table>

--- a/extensions/ki_timesheets/templates/scripts/timeSheet.php
+++ b/extensions/ki_timesheets/templates/scripts/timeSheet.php
@@ -78,31 +78,31 @@ if ($this->timeSheetEntries) {
                             <?php if ($this->kga->isShowRecordAgain()): ?>
                             <a onclick="ts_ext_recordAgain(<?php echo $row['projectID']?>,<?php echo $row['activityID']?>,<?php echo $row['timeEntryID']?>); return false;"
                                href="#" class="recordAgain"><img src="<?php echo $this->skin('grfx/button_recordthis.gif'); ?>"
-                                                                 width="13" height="13" alt='<?php echo $this->kga['lang']['recordAgain']?>' title='<?php echo $this->kga['lang']['recordAgain']?> (ID:<?php echo $row['timeEntryID']?>)' border='0' /></a>
+                                                                 width="13" height="13" alt='<?php echo $this->translate('recordAgain')?>' title="<?php echo $this->translate('recordAgain')?> (ID:<?php echo $row['timeEntryID']?>)" border="0" /></a>
                             <?php endif; ?>
                         <?php else: ?>
                             <a href="#" class="stop" onclick="ts_ext_stopRecord(<?php echo $row['timeEntryID']?>); return false;"><img
                                         src="<?php echo $this->skin('grfx/button_stopthis.gif'); ?>" width="13"
-                                        height="13" alt='<?php echo $this->kga['lang']['stop']?>' title='<?php echo $this->kga['lang']['stop']?> (ID:<?php echo $row['timeEntryID']?>)' border='0' /></a>
+                                        height="13" alt='<?php echo $this->translate('stop')?>' title="<?php echo $this->translate('stop')?> (ID: <?php echo $row['timeEntryID']?>)" border="0" /></a>
                         <?php endif; ?>
 
                         <?php if (!$this->kga->isEditLimit() || time() - $row['end'] <= $this->kga->getEditLimit()): ?>
                             <a href="#" onclick="editRecord(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"
-                               title='<?php echo $this->kga['lang']['edit']?>'><img
+                               title="<?php echo $this->translate('edit')?>"><img
                                         src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13"
-                                        alt='<?php echo $this->kga['lang']['edit']?>' title='<?php echo $this->kga['lang']['edit']?>' border="0" /></a>
+                                        alt="<?php echo $this->translate('edit')?>" title="<?php echo $this->translate('edit')?>" border="0" /></a>
 
                             <?php if ($this->kga->getSettings()->isShowQuickNote()): ?>
                                 <a href="#" onclick="editQuickNote(<?php echo $row['timeEntryID']?>); $(this).blur(); return false;"
-                                   title='<?php echo $this->kga['lang']['editNote']?>'><img
+                                   title='<?php echo $this->translate('editNote')?>'><img
                                             src="<?php echo $this->skin('grfx/editor_icon.png'); ?>" width="14" height="14"
-                                            alt="<?php echo $this->kga['lang']['editNote']?>" title='<?php echo $this->kga['lang']['editNote']?>' border="0" /></a>
+                                            alt="<?php echo $this->translate('editNote')?>" title="<?php echo $this->translate('editNote')?>" border="0" /></a>
                             <?php endif; ?>
 
                             <?php if ($this->kga->getSettings()->isShowQuickDelete()): ?>
                                 <a href="#" class="quickdelete" onclick="quickdelete(<?php echo $row['timeEntryID']?>); return false;"><img
-                                            src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" width='13'
-                                            height="13" alt='<?php echo $this->kga['lang']['quickdelete']?>' title='<?php echo $this->kga['lang']['quickdelete']?>'
+                                            src="<?php echo $this->skin('grfx/button_trashcan.png'); ?>" width="13"
+                                            height="13" alt="<?php echo $this->translate('quickdelete')?>" title="<?php echo $this->translate('quickdelete')?>"
                                             border="0" /></a>
                             <?php endif; ?>
                         <?php endif; ?>

--- a/templates/scripts/core/main.php
+++ b/templates/scripts/core/main.php
@@ -52,18 +52,18 @@
     <script type="text/javascript">
         var skin = "<?php echo $this->escape($this->skin()->getName()); ?>";
 
-        var lang_checkUsername = "<?php echo $this->escape($this->kga['lang']['checkUsername']); ?>";
-        var lang_checkGroupname = "<?php echo $this->escape($this->kga['lang']['checkGroupname']); ?>";
-        var lang_checkStatusname = "<?php echo $this->escape($this->kga['lang']['checkStatusname']); ?>";
-        var lang_passwordsDontMatch = "<?php echo $this->escape($this->kga['lang']['passwordsDontMatch']); ?>";
-        var lang_passwordTooShort = "<?php echo $this->escape($this->kga['lang']['passwordTooShort']); ?>";
-        var lang_sure = "<?php echo $this->escape($this->kga['lang']['sure']); ?>";
+        var lang_checkUsername = "<?php echo $this->escape($this->translate('checkUsername')); ?>";
+        var lang_checkGroupname = "<?php echo $this->escape($this->translate('checkGroupname')); ?>";
+        var lang_checkStatusname = "<?php echo $this->escape($this->translate('checkStatusname')); ?>";
+        var lang_passwordsDontMatch = "<?php echo $this->escape($this->translate('passwordsDontMatch')); ?>";
+        var lang_passwordTooShort = "<?php echo $this->escape($this->translate('passwordTooShort')); ?>";
+        var lang_sure = "<?php echo $this->escape($this->translate('sure')); ?>";
 
         var currentRecording = <?php echo $this->currentRecording?>;
         var openAfterRecorded = <?php echo json_encode($this->openAfterRecorded) ?>;
 
         <?php if ($this->kga->getSettings()->getQuickDeleteType() == 2): ?>
-        var confirmText = "<?php echo $this->escape($this->kga['lang']['sure']) ?>";
+        var confirmText = "<?php echo $this->escape($this->translate('sure')) ?>";
         <?php else: ?>
         var confirmText = undefined;
         <?php endif; ?>
@@ -196,14 +196,14 @@
                     alt="Logout"/></a>
         <a id="main_tools_button" href="#"><img src="<?php echo $this->skin('grfx/g3_menu_dropdown.png'); ?>" width="44"
                                                 height="27" alt="Menu Dropdown"/></a>
-        <br/><?php echo $this->kga['lang']['logged_in_as'] ?>
+        <br/><?php echo $this->translate('logged_in_as') ?>
         <b><?php echo isset($this->kga['user']) ? $this->escape($this->kga['user']['name']) : $this->escape($this->kga['customer']['name']) ?></b>
     </div>
     <div id="main_tools_menu">
         <div class="slider">
-            <a href="#" id="main_credits_button"><?php echo $this->kga['lang']['about'] ?></a>
+            <a href="#" id="main_credits_button"><?php echo $this->translate('about') ?></a>
             <?php if (!isset($this->kga['customer'])) { ?>
-                | <a href="#" id="main_prefs_button"><?php echo $this->kga['lang']['preferences'] ?></a>
+                | <a href="#" id="main_prefs_button"><?php echo $this->translate('preferences') ?></a>
             <?php } ?>
         </div>
         <div class="end"></div>
@@ -236,7 +236,7 @@
 
         <div id="infos">
             <span id="n_date"></span>&nbsp;
-            <a href="#" title="<?php echo $this->escape($this->kga['lang']['now']); ?>"
+            <a href="#" title="<?php echo $this->escape($this->translate('now')); ?>"
                onclick="setTimeframe(new Date(),new Date()); return false;"><img
                         src="<?php echo $this->skin('grfx/timeframe_now.png'); ?>" width="12" height="14"
                         alt="Select date of today"/></a>&nbsp;
@@ -251,14 +251,14 @@
     <?php if (isset($this->kga['user'])): ?>
         <div id="selector">
             <div class="preselection">
-                <strong><?php echo $this->kga['lang']['selectedForRecording'] ?></strong><br/>
-                <strong class="short"><?php echo $this->kga['lang']['selectedCustomerLabel'] ?></strong><span
+                <strong><?php echo $this->translate('selectedForRecording') ?></strong><br/>
+                <strong class="short"><?php echo $this->translate('selectedCustomerLabel') ?></strong><span
                         class="selection"
                         id="selected_customer"><?php echo $this->escape($this->customerData['name']) ?></span><br/>
-                <strong class="short"><?php echo $this->kga['lang']['selectedProjectLabel'] ?></strong><span
+                <strong class="short"><?php echo $this->translate('selectedProjectLabel') ?></strong><span
                         class="selection"
                         id="selected_project"><?php echo $this->escape($this->projectData['name']) ?></span><br/>
-                <strong class="short"><?php echo $this->kga['lang']['selectedActivityLabel'] ?></strong><span
+                <strong class="short"><?php echo $this->translate('selectedActivityLabel') ?></strong><span
                         class="selection"
                         id="selected_activity"><?php echo $this->escape($this->activityData['name']) ?></span><br/>
             </div>
@@ -281,49 +281,40 @@
 <div id="topactions">
     <div id="settimer">
         <a style="cursor: pointer;"
-           onclick="setTimerToToday(); return false;"><?php echo $this->kga['lang']['quicklink_today'] ?></a> |
+           onclick="setTimerToToday(); return false;"><?php echo $this->translate('quicklink_today') ?></a> |
         <a style="cursor: pointer;"
-           onclick="setTimerToYesterday(); return false;"><?php echo $this->kga['lang']['quicklink_yesterday'] ?></a> |
+           onclick="setTimerToYesterday(); return false;"><?php echo $this->translate('quicklink_yesterday') ?></a> |
         <a style="cursor: pointer;"
-           onclick="setTimerToLastWeek(); return false;"><?php echo $this->kga['lang']['quicklink_lastWeek'] ?></a> |
+           onclick="setTimerToLastWeek(); return false;"><?php echo $this->translate('quicklink_lastWeek') ?></a> |
         <a style="cursor: pointer;"
-           onclick="setTimerToLastMonth(); return false;"><?php echo $this->kga['lang']['quicklink_lastMonth'] ?></a> |
+           onclick="setTimerToLastMonth(); return false;"><?php echo $this->translate('quicklink_lastMonth') ?></a> |
         <a style="cursor: pointer;"
-           onclick="setTimerToCurrentWeek(); return false;"><?php echo $this->kga['lang']['quicklink_thisWeek'] ?></a> |
+           onclick="setTimerToCurrentWeek(); return false;"><?php echo $this->translate('quicklink_thisWeek') ?></a> |
         <a style="cursor: pointer;"
-           onclick="setTimerToCurrentMonth(); return false;"><?php echo $this->kga['lang']['quicklink_thisMonth'] ?></a>
+           onclick="setTimerToCurrentMonth(); return false;"><?php echo $this->translate('quicklink_thisMonth') ?></a>
     </div>
 </div>
 <div id="fliptabs" class="menuBackground">
     <ul class="menu">
         <li class="tab act" id="exttab_0">
-            <a href="javascript:void(0);"
-               onclick="changeTab(0,'ki_timesheets/init.php'); timesheet_extension_tab_changed();">
+            <a href="javascript:void(0);" onclick="changeTab(0,'ki_timesheets/init.php'); timesheet_extension_tab_changed();">
                 <span class="aa">&nbsp;</span>
-                <span class="bb">
-                    <?php
-                    if (isset($this->kga['lang']['extensions']['ki_timesheet'])) {
-                        echo $this->kga['lang']['extensions']['ki_timesheet'];
-                    } else {
-                        echo "Timesheet";
-                    }
-                    ?></span>
+                <span class="bb"><?php echo $this->translate('extensions:ki_timesheet'); ?></span>
                 <span class="cc">&nbsp;</span>
             </a>
         </li>
         <?php for ($i = 0; $i < count($this->extensions); $i++):
             $extension = $this->extensions[$i];
-            if (!$extension['name'] OR $extension['key'] == "ki_timesheet") {
+            if (!$extension['name'] OR $extension['key'] == 'ki_timesheet') {
                 continue;
             } ?>
             <li class="tab norm" id="exttab_<?php echo $i + 1; ?>">
                 <a href="javascript:void(0);"
                    onclick="changeTab(<?php echo $i + 1 ?>, '<?php echo $extension['initFile'] ?>'); <?php echo $extension['tabChangeTrigger'] ?>;">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb">
-                    <?php
+                    <span class="bb"><?php
                     if (isset($this->kga['lang']['extensions'][$extension['key']])) {
-                        echo $this->kga['lang']['extensions'][$extension['key']];
+                        echo $this->translate('extensions:' . $extension['key']);
                     } else {
                         echo $this->escape($extension['name']);
                     }
@@ -352,22 +343,22 @@
     <div id="users_head">
         <input class="livefilterfield" onkeyup="lists_live_filter('users', this.value);" type="text" id="filt_user"
                name="filt_user"/>
-        <?php echo $this->kga['lang']['users'] ?>
+        <?php echo $this->translate('users') ?>
     </div>
     <div id="customers_head">
         <input class="livefilterfield" onkeyup="lists_live_filter('customers', this.value);" type="text"
                id="filter_customer" name="filter_customer"/>
-        <?php echo $this->kga['lang']['customers'] ?>
+        <?php echo $this->translate('customers') ?>
     </div>
     <div id="projects_head">
         <input class="livefilterfield" onkeyup="lists_live_filter('projects', this.value);" type="text"
                id="filter_project" name="filter_project"/>
-        <?php echo $this->kga['lang']['projects'] ?>
+        <?php echo $this->translate('projects') ?>
     </div>
     <div id="activities_head">
         <input class="livefilterfield" onkeyup="lists_live_filter('activities', this.value);" type="text"
                id="filter_activity" name="filter_activity"/>
-        <?php echo $this->kga['lang']['activities'] ?>
+        <?php echo $this->translate('activities') ?>
     </div>
 
     <div id="users"><?php echo $this->user_display ?></div>

--- a/templates/scripts/floaters/add_edit_activity.php
+++ b/templates/scripts/floaters/add_edit_activity.php
@@ -2,35 +2,35 @@
     <div id="floater_handle">
         <span id="floater_title"><?php
             if (isset($this->id) && $this->id !== 0) {
-                echo $this->kga['lang']['edit'] . ': ' . $this->kga['lang']['activity'];
+                echo $this->translate('edit') . ': ' . $this->translate('activity');
             } else {
-                echo $this->kga['lang']['new_activity'];
+                echo $this->translate('new_activity');
             }
         ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#projectstab">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['projects'] ?></span>
+                    <span class="bb"><?php echo $this->translate('projects') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#groups">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['groups'] ?></span>
+                    <span class="bb"><?php echo $this->translate('groups') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#commenttab">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['comment'] ?></span>
+                    <span class="bb"><?php echo $this->translate('comment') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -44,23 +44,23 @@
             <fieldset id="general">
                 <ul>
                     <li>
-                        <label for="name"><?php echo $this->kga['lang']['activity'] ?>:</label>
+                        <label for="name"><?php echo $this->translate('activity') ?>:</label>
                         <?php echo $this->formText('name', $this->activity['name'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="defaultRate"><?php echo $this->kga['lang']['default_rate'] ?>:</label>
+                        <label for="defaultRate"><?php echo $this->translate('default_rate') ?>:</label>
                         <?php echo $this->formText('defaultRate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->activity['defaultRate'])); ?>
                     </li>
                     <li>
-                        <label for="myRate"><?php echo $this->kga['lang']['my_rate'] ?>:</label>
+                        <label for="myRate"><?php echo $this->translate('my_rate') ?>:</label>
                         <?php echo $this->formText('myRate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->activity['myRate'])); ?>
                     </li>
                     <li>
-                        <label for="fixedRate"><?php echo $this->kga['lang']['fixedRate'] ?>:</label>
+                        <label for="fixedRate"><?php echo $this->translate('fixedRate') ?>:</label>
                         <?php echo $this->formText('fixedRate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->activity['fixedRate'])); ?>
                     </li>
                     <li>
-                        <label for="visible"><?php echo $this->kga['lang']['visibility'] ?>:</label>
+                        <label for="visible"><?php echo $this->translate('visibility') ?>:</label>
                         <?php echo $this->formCheckbox('visible', '1', ['checked' => $this->activity['visible'] || !$this->id]); ?>
                     </li>
                 </ul>
@@ -112,7 +112,7 @@
             <fieldset id="groups">
                 <ul>
                     <li>
-                        <label for="activityGroups"><?php echo $this->kga['lang']['groups'] ?>:</label>
+                        <label for="activityGroups"><?php echo $this->translate('groups') ?>:</label>
                         <?php echo $this->formSelect('activityGroups[]', $this->selectedGroups, [
                             'class' => 'formfield',
                             'id' => 'activityGroups',
@@ -126,7 +126,7 @@
             <fieldset id="commenttab">
                 <ul>
                     <li>
-                        <label for="comment"><?php echo $this->kga['lang']['comment'] ?>:</label>
+                        <label for="comment"><?php echo $this->translate('comment') ?>:</label>
                         <?php echo $this->formTextarea('comment', $this->activity['comment'], [
                             'cols' => 30,
                             'rows' => 5,
@@ -138,8 +138,8 @@
             </fieldset>
         </div>
         <div id="formbuttons">
-	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->kga['lang']['cancel'] ?></button>
-            <input class="btn_ok" type="submit" value="<?php echo $this->kga['lang']['submit'] ?>"/>
+	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+            <input class="btn_ok" type="submit" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>

--- a/templates/scripts/floaters/add_edit_customer.php
+++ b/templates/scripts/floaters/add_edit_customer.php
@@ -2,40 +2,40 @@
     <div id="floater_handle">
         <span id="floater_title"><?php
             if (isset($this->id) && $this->id !== 0) {
-                echo $this->kga['lang']['edit'] . ': ' . $this->kga['lang']['customer'];
+                echo $this->translate('edit') . ': ' . $this->translate('customer');
             } else {
-                echo $this->kga['lang']['new_customer'];
+                echo $this->translate('new_customer');
             }
         ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#address">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['address'] ?></span>
+                    <span class="bb"><?php echo $this->translate('address') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#contact">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['contact'] ?></span>
+                    <span class="bb"><?php echo $this->translate('contact') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#groups">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['groups'] ?></span>
+                    <span class="bb"><?php echo $this->translate('groups') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#commenttab">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['comment'] ?></span>
+                    <span class="bb"><?php echo $this->translate('comment') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -49,30 +49,30 @@
             <fieldset id="general">
                 <ul>
                     <li>
-                        <label for="name"><?php echo $this->kga['lang']['customer'] ?>*:</label>
+                        <label for="name"><?php echo $this->translate('customer') ?>*:</label>
                         <?php echo $this->formText('name', $this->customer['name'], ['required' => 'required', 'size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="vat"><?php echo $this->kga['lang']['vat'] ?>:</label>
+                        <label for="vat"><?php echo $this->translate('vat') ?>:</label>
                         <?php echo $this->formText('vat', $this->customer['vat'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="visible"><?php echo $this->kga['lang']['visibility'] ?>:</label>
+                        <label for="visible"><?php echo $this->translate('visibility') ?>:</label>
                         <?php echo $this->formCheckbox('visible', '1', ['checked' => $this->customer['visible'] || !$this->id]); ?>
                     </li>
                     <li>
-                        <label for="password"><?php echo $this->kga['lang']['password'] ?>:</label>
+                        <label for="password"><?php echo $this->translate('password') ?>:</label>
                         <div class="multiFields">
                             <?php echo $this->formPassword('password', '', [
                                 'disabled' => (!$this->customer['password']) ? 'disabled' : '',
                                 'size' => 100
                             ]); ?><br/>
                             <?php echo $this->formCheckbox('no_password', '1', ['class' => 'disableInput', 'checked' => !$this->customer['password']]);
-                            echo $this->kga['lang']['nopassword'] ?>
+                            echo $this->translate('nopassword') ?>
                         </div>
                     </li>
                     <li>
-                        <label for="timezone"><?php echo $this->kga['lang']['timezone'] ?>:</label>
+                        <label for="timezone"><?php echo $this->translate('timezone') ?>:</label>
                         <?php echo $this->timeZoneSelect('timezone', $this->customer['timezone'], ['style' => 'width:620px']); ?>
                     </li>
                 </ul>
@@ -80,27 +80,27 @@
             <fieldset id="address">
                 <ul>
                     <li>
-                        <label for="company"><?php echo $this->kga['lang']['company'] ?>:</label>
+                        <label for="company"><?php echo $this->translate('company') ?>:</label>
                         <?php echo $this->formText('company', $this->customer['company'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="contactPerson"><?php echo $this->kga['lang']['contactPerson'] ?>:</label>
+                        <label for="contactPerson"><?php echo $this->translate('contactPerson') ?>:</label>
                         <?php echo $this->formText('contactPerson', $this->customer['contact'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="street"><?php echo $this->kga['lang']['street'] ?>:</label>
+                        <label for="street"><?php echo $this->translate('street') ?>:</label>
                         <?php echo $this->formText('street', $this->customer['street'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="zipcode"><?php echo $this->kga['lang']['zipcode'] ?>:</label>
+                        <label for="zipcode"><?php echo $this->translate('zipcode') ?>:</label>
                         <?php echo $this->formText('zipcode', $this->customer['zipcode'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="city"><?php echo $this->kga['lang']['city'] ?>:</label>
+                        <label for="city"><?php echo $this->translate('city') ?>:</label>
                         <?php echo $this->formText('city', $this->customer['city'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="country"><?php echo $this->kga['lang']['country'] ?>:</label>
+                        <label for="country"><?php echo $this->translate('country') ?>:</label>
                         <?php echo $this->formSelect('country', $this->customer['country'], [
                             'class' => 'formfield',
                             'id' => 'country',
@@ -112,23 +112,23 @@
             <fieldset id="contact">
                 <ul>
                     <li>
-                        <label for="phone"><?php echo $this->kga['lang']['telephon'] ?>:</label>
+                        <label for="phone"><?php echo $this->translate('telephon') ?>:</label>
                         <?php echo $this->formText('phone', $this->customer['phone'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="fax"><?php echo $this->kga['lang']['fax'] ?>:</label>
+                        <label for="fax"><?php echo $this->translate('fax') ?>:</label>
                         <?php echo $this->formText('fax', $this->customer['fax'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="mobile"><?php echo $this->kga['lang']['mobilephone'] ?>:</label>
+                        <label for="mobile"><?php echo $this->translate('mobilephone') ?>:</label>
                         <?php echo $this->formText('mobile', $this->customer['mobile'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="mail"><?php echo $this->kga['lang']['mail'] ?>:</label>
+                        <label for="mail"><?php echo $this->translate('mail') ?>:</label>
                         <?php echo $this->formText('mail', $this->customer['mail'], ['size' => 100]); ?>
                     </li>
                     <li>
-                        <label for="homepage"><?php echo $this->kga['lang']['homepage'] ?>:</label>
+                        <label for="homepage"><?php echo $this->translate('homepage') ?>:</label>
                         <?php echo $this->formText('homepage', $this->customer['homepage'], ['size' => 100]); ?>
                     </li>
                 </ul>
@@ -136,7 +136,7 @@
             <fieldset id="groups">
                 <ul>
                     <li>
-                        <label for="customerGroups"><?php echo $this->kga['lang']['groups'] ?>:</label>
+                        <label for="customerGroups"><?php echo $this->translate('groups') ?>:</label>
                         <?php echo $this->formSelect('customerGroups[]', $this->selectedGroups, [
                             'class' => 'formfield',
                             'id' => 'customerGroups',
@@ -150,7 +150,7 @@
             <fieldset id="commenttab">
                 <ul>
                     <li>
-                        <label for="comment"><?php echo $this->kga['lang']['comment'] ?>:</label>
+                        <label for="comment"><?php echo $this->translate('comment') ?>:</label>
                         <?php echo $this->formTextarea('comment', $this->customer['comment'], [
                             'cols' => 30,
                             'rows' => 5,
@@ -162,8 +162,8 @@
             </fieldset>
         </div>
         <div id="formbuttons">
-	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->kga['lang']['cancel'] ?></button>
-            <input class="btn_ok" type="submit" value="<?php echo $this->kga['lang']['submit'] ?>"/>
+	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+            <input class="btn_ok" type="submit" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>

--- a/templates/scripts/floaters/add_edit_project.php
+++ b/templates/scripts/floaters/add_edit_project.php
@@ -2,38 +2,40 @@
     <div id="floater_handle">
         <span id="floater_title"><?php
             if (isset($this->id) && $this->id !== 0) {
-                echo $this->kga['lang']['edit'] . ': ' . $this->kga['lang']['project'];
+                echo $this->translate('edit') . ': ' . $this->translate('project');
             } else {
-                echo $this->kga['lang']['new_project'];
+                echo $this->translate('new_project');
             }
         ?></span>
-        <div class="right"><a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a></div>
+        <div class="right">
+	        <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
+        </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#general">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#money">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['budget'] ?></span>
+                    <span class="bb"><?php echo $this->translate('budget') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#activitiestab">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['activities'] ?></span>
+                    <span class="bb"><?php echo $this->translate('activities') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#groups">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['groups'] ?></span>
+                    <span class="bb"><?php echo $this->translate('groups') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#comment">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['comment'] ?></span>
+                    <span class="bb"><?php echo $this->translate('comment') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -46,38 +48,38 @@
         <div id="floater_tabs" class="floater_content">
             <fieldset id="general">
                 <ul>
-                    <li><label for="name"><?php echo $this->kga['lang']['project'] ?>*:</label>
+                    <li><label for="name"><?php echo $this->translate('project') ?>*:</label>
                         <?php echo $this->formText('name', $this->project['name'], ['required' => 'required', 'size' => 100]); ?>
                     </li>
-                    <li><label for="customerID"><?php echo $this->kga['lang']['customer'] ?>:</label>
+                    <li><label for="customerID"><?php echo $this->translate('customer') ?>:</label>
                         <?php echo $this->formSelect('customerID', $this->project['customerID'], ['class' => 'formfield', 'style' => 'width:620px'], $this->customers); ?>
                     </li>
-                    <li><label for="visible"><?php echo $this->kga['lang']['visibility'] ?>:</label>
+                    <li><label for="visible"><?php echo $this->translate('visibility') ?>:</label>
                         <?php echo $this->formCheckbox('visible', '1', ['checked' => $this->project['visible'] || !$this->id]); ?>
                     </li>
-                    <li><label for="internal"><?php echo $this->kga['lang']['internalProject'] ?>:</label>
+                    <li><label for="internal"><?php echo $this->translate('internalProject') ?>:</label>
                         <?php echo $this->formCheckbox('internal', '1', ['checked' => $this->project['internal']]); ?>
                     </li>
                 </ul>
             </fieldset>
             <fieldset id="money">
                 <ul>
-                    <li><label for="defaultRate"><?php echo $this->kga['lang']['default_rate'] ?>:</label>
+                    <li><label for="defaultRate"><?php echo $this->translate('default_rate') ?>:</label>
                         <?php echo $this->formText('defaultRate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->project['defaultRate'])); ?>
                     </li>
-                    <li><label for="myRate"><?php echo $this->kga['lang']['my_rate'] ?>:</label>
+                    <li><label for="myRate"><?php echo $this->translate('my_rate') ?>:</label>
                         <?php echo $this->formText('myRate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->project['myRate'])); ?>
                     </li>
-                    <li><label for="fixedRate"><?php echo $this->kga['lang']['fixedRate'] ?>:</label>
+                    <li><label for="fixedRate"><?php echo $this->translate('fixedRate') ?>:</label>
                         <?php echo $this->formText('fixedRate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->project['fixedRate'])); ?>
                     </li>
-                    <li><label for="project_budget"><?php echo $this->kga['lang']['budget'] ?>:</label>
+                    <li><label for="project_budget"><?php echo $this->translate('budget') ?>:</label>
                         <?php echo $this->formText('project_budget', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->project['budget'])); ?>
                     </li>
-                    <li><label for="project_effort"><?php echo $this->kga['lang']['effort'] ?>:</label>
+                    <li><label for="project_effort"><?php echo $this->translate('effort') ?>:</label>
                         <?php echo $this->formText('project_effort', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->project['effort'])); ?>
                     </li>
-                    <li><label for="project_approved"><?php echo $this->kga['lang']['approved'] ?>:</label>
+                    <li><label for="project_approved"><?php echo $this->translate('approved') ?>:</label>
                         <?php echo $this->formText('project_approved', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->project['approved'])); ?>
                     </li>
                 </ul>
@@ -85,10 +87,10 @@
             <fieldset id="activitiestab">
                 <table class="activitiesTable">
                     <tr>
-                        <td><label for="assignedActivities" style="text-align: left;"><?php echo $this->kga['lang']['activities'] ?>:</label></td>
-                        <td><label for="budget" style="text-align: left;"><?php echo $this->kga['lang']['budget'] ?>:</label></td>
-                        <td><label for="effort" style="text-align: left;"><?php echo $this->kga['lang']['effort'] ?>:</label></td>
-                        <td><label for="approved" style="text-align: left;"><?php echo $this->kga['lang']['approved'] ?>:</label></td>
+                        <td><label for="assignedActivities" style="text-align: left;"><?php echo $this->translate('activities') ?>:</label></td>
+                        <td><label for="budget" style="text-align: left;"><?php echo $this->translate('budget') ?>:</label></td>
+                        <td><label for="effort" style="text-align: left;"><?php echo $this->translate('effort') ?>:</label></td>
+                        <td><label for="approved" style="text-align: left;"><?php echo $this->translate('approved') ?>:</label></td>
                         <td></td>
                     </tr>
                     <?php
@@ -147,7 +149,7 @@
             </fieldset>
             <fieldset id="comment">
                 <ul>
-                    <li><label for="projectComment"><?php echo $this->kga['lang']['comment'] ?>:</label>
+                    <li><label for="projectComment"><?php echo $this->translate('comment') ?>:</label>
                         <?php echo $this->formTextarea('projectComment', $this->project['comment'], [
                             'cols' => 30,
                             'rows' => 5,
@@ -159,8 +161,8 @@
             </fieldset>
         </div>
         <div id="formbuttons">
-	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->kga['lang']['cancel'] ?></button>
-            <input class='btn_ok' type='submit' value='<?php echo $this->kga['lang']['submit'] ?>'/>
+	        <button type="button" class="btn_norm" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+            <input type="submit" class="btn_ok" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>

--- a/templates/scripts/floaters/credits.php
+++ b/templates/scripts/floaters/credits.php
@@ -1,8 +1,8 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['about']?></span>
+        <span id="floater_title"><?php echo $this->translate('about')?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close']?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="floater_content" style="margin:10px">
@@ -22,7 +22,7 @@
         <p>
             <strong><?php
                 echo sprintf(
-                    $this->kga['lang']['credits_license'],
+                    $this->translate('credits_license'),
                     '<a href="../COPYING" target="_blank">GPL 3</a>'
                 );
             ?></strong>
@@ -30,7 +30,7 @@
         <p>
             <?php
             echo sprintf(
-                $this->kga['lang']['credits'],
+                $this->translate('credits'),
                 'http://forum.kimai.org',
                 'https://github.com/kimai/kimai/archive/master.zip',
                 'https://www.kimai.org/donate/',
@@ -40,14 +40,14 @@
             ?>
         </p>
         <p>
-            <strong><?php echo $this->kga['lang']['credits_thanks']?></strong>
+            <strong><?php echo $this->translate('credits_thanks')?></strong>
             Vasilis van Gemert, Maximilian Kern, Enrico Ties, Thomas Wensing, John Resig, Kelvin Luck, Urs Gerig, Willem van Gemert,
             Torben Boe and HamBug Studios, Klaus Franken, Chris (Urban Willi), Andreas Berndt, Niels Hoffmann, Günter Hengsbach,
             Paul Brand, Joaqu&iacute;n G. de la Zerda, Allesandro Bertoldo, Jos&eacute; Ricardo Cardoso,
             RRZE (Regionales Rechenzentrum Erlangen) ...
         </p>
         <p>
-            <strong><?php echo $this->kga['lang']['credits_libs']?></strong>
+            <strong><?php echo $this->translate('credits_libs')?></strong>
                 <a href="http://framework.zend.com/" target="_blank">Zend Framework</a>,
                 <a href="http://jquery.com/" target="_blank">jQuery</a>,
                 <a href="http://phpjs.org/" target="_blank">phpjs</a>,

--- a/templates/scripts/floaters/preferences.php
+++ b/templates/scripts/floaters/preferences.php
@@ -1,25 +1,25 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['preferences'] ?></span>
+        <span id="floater_title"><?php echo $this->translate('preferences') ?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close'] ?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="menuBackground">
         <ul class="menu tabSelection">
             <li class="tab norm"><a href="#prefGeneral">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['general'] ?></span>
+                    <span class="bb"><?php echo $this->translate('general') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#prefSublists">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['sublists'] ?></span>
+                    <span class="bb"><?php echo $this->translate('sublists') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
             <li class="tab norm"><a href="#prefList">
                     <span class="aa">&nbsp;</span>
-                    <span class="bb"><?php echo $this->kga['lang']['list'] ?></span>
+                    <span class="bb"><?php echo $this->translate('list') ?></span>
                     <span class="cc">&nbsp;</span>
                 </a></li>
         </ul>
@@ -31,133 +31,133 @@
             <fieldset id="prefGeneral">
                 <ul>
                     <li>
-                        <label for="skin"><?php echo $this->kga['lang']['skin'] ?>:</label>
+                        <label for="skin"><?php echo $this->translate('skin') ?>:</label>
                         <?php echo $this->formSelect('skin', $this->skin()->getName(), null, $this->skins); ?>
                     </li>
                     <li>
-                        <label for="password"><?php echo $this->kga['lang']['newPassword'] ?>:</label>
-                        <input type="password" name="password" size="15" id="password"/> <?php echo $this->kga['lang']['minLength'] ?>
+                        <label for="password"><?php echo $this->translate('newPassword') ?>:</label>
+                        <input type="password" name="password" size="15" id="password"/> <?php echo $this->translate('minLength') ?>
                     </li>
                     <li>
-                        <label for="retypePassword"><?php echo $this->kga['lang']['retypePassword'] ?>:</label>
+                        <label for="retypePassword"><?php echo $this->translate('retypePassword') ?>:</label>
                         <input type="password" name="retypePassword" size="15" id="retypePassword"/>
                     </li>
                     <li>
-                        <label for="rate"><?php echo $this->kga['lang']['my_rate'] ?>:</label>
+                        <label for="rate"><?php echo $this->translate('my_rate') ?>:</label>
                         <?php echo $this->formText('rate', str_replace('.', $this->kga['conf']['decimalSeparator'], $this->rate), [
                             'size' => 9
                         ]); ?>
                     </li>
                     <li>
-                        <label for="lang"><?php echo $this->kga['lang']['lang'] ?>:</label>
+                        <label for="lang"><?php echo $this->translate('lang') ?>:</label>
                         <?php echo $this->formSelect('lang', $this->kga->getLanguage(), null, $this->langs); ?>
                     </li>
                     <li>
-                        <label for="timezone"><?php echo $this->kga['lang']['timezone'] ?>:</label>
+                        <label for="timezone"><?php echo $this->translate('timezone') ?>:</label>
                         <?php echo $this->timeZoneSelect('timezone', $this->kga['timezone']); ?>
                     </li>
                     <li>
                         <label for="autoselection"></label>
                         <?php echo $this->formCheckbox('autoselection', '1', ['checked' => $this->kga->getSettings()->isUseAutoSelection()]);
-                        echo $this->kga['lang']['autoselection'] ?>
+                        echo $this->translate('autoselection') ?>
                     </li>
                     <li>
                         <label for="openAfterRecorded"></label>
                         <?php echo $this->formCheckbox('openAfterRecorded', '1', ['checked' => $this->kga->getSettings()->isShowAfterRecorded()]);
-                        echo $this->kga['lang']['openAfterRecorded'] ?>
+                        echo $this->translate('openAfterRecorded') ?>
                     </li>
                 </ul>
             </fieldset>
             <fieldset id="prefSublists">
                 <ul>
                     <li>
-                        <?php echo $this->kga['lang']['sublistAnnotations'] ?>:
+                        <?php echo $this->translate('sublistAnnotations') ?>:
                         <?php echo $this->formSelect('sublistAnnotations', $this->kga->getSettings()->getSublistAnnotationType(), null, [
-                            $this->kga['lang']['timelabel'], $this->kga['lang']['export_extension']['costs'], $this->kga['lang']['timelabel'] . ' & ' . $this->kga['lang']['export_extension']['costs']
+                            $this->translate('timelabel'), $this->translate('export_extension:costs'), $this->translate('timelabel') . ' & ' . $this->translate('export_extension:costs')
                         ]); ?>
                     </li>
                     <li>
                         <label for="flip_project_display"></label>
                         <?php echo $this->formCheckbox('flip_project_display', '1', ['checked' => $this->kga->getSettings()->isFlipProjectDisplay()]),
-                        $this->kga['lang']['flip_project_display'] ?>
+                        $this->translate('flip_project_display') ?>
                     </li>
                     <li>
                         <label for="project_comment_flag"></label>
                         <?php echo $this->formCheckbox('project_comment_flag', '1', ['checked' => $this->kga->getSettings()->isShowProjectComment()]),
-                        $this->kga['lang']['project_comment_flag'] ?>
+                        $this->translate('project_comment_flag') ?>
                     </li>
                     <li>
                         <label for="showIDs"></label>
                         <?php echo $this->formCheckbox('showIDs', '1', ['checked' => $this->kga->getSettings()->isShowIds()]),
-                        $this->kga['lang']['showIDs'] ?>
+                        $this->translate('showIDs') ?>
                     </li>
                     <li>
                         <label for="noFading"></label>
                         <?php echo $this->formCheckbox('noFading', '1', ['checked' => !$this->kga->getSettings()->isUseSmoothFading()]),
-                        $this->kga['lang']['noFading'] ?>
+                        $this->translate('noFading') ?>
                     </li>
                     <li>
                         <label for="user_list_hidden"></label>
                         <?php echo $this->formCheckbox('user_list_hidden', '1', ['checked' => $this->kga->getSettings()->isUserListHidden()]),
-                        $this->kga['lang']['user_list_hidden'] ?>
+                        $this->translate('user_list_hidden') ?>
                     </li>
                 </ul>
             </fieldset>
             <fieldset id="prefList">
                 <ul>
                     <li>
-                        <label for="rowlimit"><?php echo $this->kga['lang']['rowlimit'] ?>:</label>
+                        <label for="rowlimit"><?php echo $this->translate('rowlimit') ?>:</label>
                         <?php echo $this->formText('rowlimit', $this->kga->getSettings()->getRowLimit(), ['size' => 9]); ?>
                     </li>
                     <li>
                         <label for="hideClearedEntries"></label>
-                        <?php echo $this->formCheckbox('hideClearedEntries', '1', ['checked' => $this->kga->getSettings()->isHideClearedEntries()]), $this->kga['lang']['hideClearedEntries'] ?>
+                        <?php echo $this->formCheckbox('hideClearedEntries', '1', ['checked' => $this->kga->getSettings()->isHideClearedEntries()]), $this->translate('hideClearedEntries') ?>
                     </li>
                     <li>
-                        <?php echo $this->kga['lang']['quickdelete'] ?>:
-                        <?php echo $this->formSelect('quickdelete', $this->kga->getSettings()->getQuickDeleteType(), null, [$this->kga['lang']['quickdeleteHide'], $this->kga['lang']['quickdeleteShow'], $this->kga['lang']['quickdeleteShowConfirm']]); ?>
+                        <?php echo $this->translate('quickdelete') ?>:
+                        <?php echo $this->formSelect('quickdelete', $this->kga->getSettings()->getQuickDeleteType(), null, [$this->translate('quickdeleteHide'), $this->translate('quickdeleteShow'), $this->translate('quickdeleteShowConfirm')]); ?>
                     </li>
                     <li>
                         <label for="showCommentsByDefault"></label>
-                        <?php echo $this->formCheckbox('showCommentsByDefault', '1', ['checked' => $this->kga->getSettings()->isShowComments()]), $this->kga['lang']['showCommentsByDefault'] ?>
+                        <?php echo $this->formCheckbox('showCommentsByDefault', '1', ['checked' => $this->kga->getSettings()->isShowComments()]), $this->translate('showCommentsByDefault') ?>
                     </li>
                     <?php if ($this->kga->isTrackingNumberEnabled()) { ?>
                     <li>
                         <label for="showTrackingNumber"></label>
-                        <?php echo $this->formCheckbox('showTrackingNumber', '1', ['checked' => $this->kga->getSettings()->isShowTrackingNumber()]), $this->kga['lang']['showTrackingNumber'] ?>
+                        <?php echo $this->formCheckbox('showTrackingNumber', '1', ['checked' => $this->kga->getSettings()->isShowTrackingNumber()]), $this->translate('showTrackingNumber') ?>
                     </li>
                     <?php } ?>
                     <li>
                         <label for="showBillability"></label>
-                        <?php echo $this->formCheckbox('showBillability', '1', ['checked' => $this->kga->getSettings()->isShowBillability()]), $this->kga['lang']['showBillability'] ?>
+                        <?php echo $this->formCheckbox('showBillability', '1', ['checked' => $this->kga->getSettings()->isShowBillability()]), $this->translate('showBillability') ?>
                     </li>
                     <li>
                         <label for="hideOverlapLines"></label>
-                        <?php echo $this->formCheckbox('hideOverlapLines', '1', ['checked' => !$this->kga->getSettings()->isShowOverlapLines()]), $this->kga['lang']['hideOverlapLines'] ?>
+                        <?php echo $this->formCheckbox('hideOverlapLines', '1', ['checked' => !$this->kga->getSettings()->isShowOverlapLines()]), $this->translate('hideOverlapLines') ?>
                     </li>
                     <li>
-                        <label for="defaultLocation"><?php echo $this->kga['lang']['defaultLocation']?>:</label>
+                        <label for="defaultLocation"><?php echo $this->translate('defaultLocation')?>:</label>
                         <?php echo $this->formText('defaultLocation', $this->kga->getSettings()->getDefaultLocation(), ['size' => 20]); ?>
                     </li>
                     <li>
                         <label for="showQuickNote"></label>
-                        <?php echo $this->formCheckbox('showQuickNote', '1', ['checked' => $this->kga->getSettings()->isShowQuickNote()]), $this->kga['lang']['showQuickNote'] ?>
+                        <?php echo $this->formCheckbox('showQuickNote', '1', ['checked' => $this->kga->getSettings()->isShowQuickNote()]), $this->translate('showQuickNote') ?>
                     </li>
                     <li>
                         <label for="inlineEditingOfDescriptions"></label>
-                        <?php echo $this->formCheckbox('inlineEditingOfDescriptions', '1', ['checked' => $this->kga->getSettings()->isInlineEditingOfDescriptionsSet()]), $this->kga['lang']['inlineEditingOfDescriptions'] ?>
+                        <?php echo $this->formCheckbox('inlineEditingOfDescriptions', '1', ['checked' => $this->kga->getSettings()->isInlineEditingOfDescriptionsSet()]), $this->translate('inlineEditingOfDescriptions') ?>
                     </li>
                     <li>
                         <label for="table_time_format"></label>
-                        <?php echo $this->kga['lang']['table_time_format']?>:
+                        <?php echo $this->translate('table_time_format')?>:
                         <?php echo $this->formText('table_time_format', $this->prefs['table_time_format'], ['size' => 20]); ?>
                     </li>
                 </ul>
             </fieldset>
         </div>
         <div id="formbuttons">
-	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->kga['lang']['cancel'] ?></button>
-            <input class="btn_ok" type="submit" value="<?php echo $this->kga['lang']['submit'] ?>"/>
+	        <button class="btn_norm" type="button" onclick="floaterClose();"><?php echo $this->translate('cancel') ?></button>
+            <input class="btn_ok" type="submit" value="<?php echo $this->translate('submit') ?>"/>
         </div>
     </form>
 </div>

--- a/templates/scripts/floaters/security_warning.php
+++ b/templates/scripts/floaters/security_warning.php
@@ -1,13 +1,13 @@
 <div id="floater_innerwrap">
     <div id="floater_handle">
-        <span id="floater_title"><?php echo $this->kga['lang']['securityWarning']?></span>
+        <span id="floater_title"><?php echo $this->translate('securityWarning')?></span>
         <div class="right">
-            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->kga['lang']['close']?></a>
+            <a href="#" class="close" onclick="floaterClose();return false;"><?php echo $this->translate('close') ?></a>
         </div>
     </div>
     <div class="floater_content" style="padding:20px">
-        <h2 style="color:red"><?php echo $this->kga['lang']['securityWarning']?></h2>
-        <b><?php echo $this->kga['lang']['installerWarningHeadline']?></b> <br/><br/>
-        <?php echo $this->kga['lang']['installerWarningText']?>
+        <h2 style="color:red"><?php echo $this->translate('securityWarning')?></h2>
+        <b><?php echo $this->translate('installerWarningHeadline')?></b> <br/><br/>
+        <?php echo $this->translate('installerWarningText')?>
     </div>
 </div>

--- a/templates/scripts/lists/activities.php
+++ b/templates/scripts/lists/activities.php
@@ -15,23 +15,23 @@ $activities = $this->filterListEntries($this->activities);
                         <a href="#"
                            onclick="editSubject('activity',<?php echo $activity['activityID'] ?>); $(this).blur(); return false;">
                             <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13'
-                                 alt='<?php echo $this->kga['lang']['edit'] ?>'
-                                 title='<?php echo $this->kga['lang']['edit'] ?> (ID:<?php echo $activity['activityID'] ?>)'
+                                 alt='<?php echo $this->translate('edit') ?>'
+                                 title='<?php echo $this->translate('edit') ?> (ID:<?php echo $activity['activityID'] ?>)'
                                  border='0'/>
                         </a>
                     <?php endif; ?>
                     <a href="#"
                        onclick="lists_update_filter('activity',<?php echo $activity['activityID'] ?>); $(this).blur(); return false;">
                         <img src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13'
-                             alt='<?php echo $this->kga['lang']['filter'] ?>'
-                             title='<?php echo $this->kga['lang']['filter'] ?>' border='0'/>
+                             alt='<?php echo $this->translate('filter') ?>'
+                             title='<?php echo $this->translate('filter') ?>' border='0'/>
                     </a>
                     <a href="#" class="preselect"
                        onclick="buzzer_preselect_activity(<?php echo $activity['activityID'] ?>,'<?php echo $this->jsEscape($activity['name']) ?>'); return false;"
                        id="ps<?php echo $activity['activityID'] ?>">
                         <img src="<?php echo $this->skin('grfx/preselect_off.png'); ?>" width='13' height='13'
-                             alt='<?php echo $this->kga['lang']['select'] ?>'
-                             title='<?php echo $this->kga['lang']['select'] ?> (ID:<?php echo $activity['activityID'] ?>)'
+                             alt='<?php echo $this->translate('select') ?>'
+                             title='<?php echo $this->translate('select') ?> (ID:<?php echo $activity['activityID'] ?>)'
                              border='0'/>
                     </a>
                 </td>

--- a/templates/scripts/lists/customers.php
+++ b/templates/scripts/lists/customers.php
@@ -18,15 +18,15 @@ $customers = $this->filterListEntries($this->customers);
                         <a href="#"
                            onclick="editSubject('customer',<?php echo $customer['customerID'] ?>); $(this).blur(); return false;">
                             <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width="13" height="13"
-                                 alt='<?php echo $this->kga['lang']['edit'] ?>'
-                                 title='<?php echo $this->kga['lang']['edit'] ?>' border="0"/>
+                                 alt='<?php echo $this->translate('edit') ?>'
+                                 title='<?php echo $this->translate('edit') ?>' border="0"/>
                         </a>
                     <?php endif; ?>
                     <a href="#"
                        onclick="lists_update_filter('customer',<?php echo $customer['customerID'] ?>); $(this).blur(); return false;">
                         <img src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13'
-                             alt='<?php echo $this->kga['lang']['filter'] ?>'
-                             title='<?php echo $this->kga['lang']['filter'] ?>' border="0"/>
+                             alt='<?php echo $this->translate('filter') ?>'
+                             title='<?php echo $this->translate('filter') ?>' border="0"/>
                     </a>
                 </td>
                 <td width="100%" class="clients" onmouseover="lists_change_color(this,true);"

--- a/templates/scripts/lists/projects.php
+++ b/templates/scripts/lists/projects.php
@@ -14,28 +14,27 @@ $projects = $this->filterListEntries($this->projects);
                     'even'
                 ])->next() ?>">
                 <td nowrap class="option">
-
                     <?php if ($this->show_project_edit_button): ?>
                         <a href="#"
                            onclick="editSubject('project',<?php echo $project['projectID'] ?>); $(this).blur(); return false;">
                             <img src="<?php echo $this->skin('grfx/edit2.gif'); ?>" width='13' height='13'
-                                 alt='<?php echo $this->kga['lang']['edit'] ?>'
-                                 title='<?php echo $this->kga['lang']['edit'] ?> (ID:<?php echo $project['projectID'] ?>)'
+                                 alt='<?php echo $this->translate('edit') ?>'
+                                 title='<?php echo $this->translate('edit') ?> (ID:<?php echo $project['projectID'] ?>)'
                                  border='0'/>
                         </a>
                     <?php endif; ?>
                     <a href="#"
                        onclick="lists_update_filter('project',<?php echo $project['projectID'] ?>); $(this).blur(); return false;">
                         <img src="<?php echo $this->skin('grfx/filter.png'); ?>" width='13' height='13'
-                             alt='<?php echo $this->kga['lang']['filter'] ?>'
-                             title='<?php echo $this->kga['lang']['filter'] ?>' border='0'/>
+                             alt='<?php echo $this->translate('filter') ?>'
+                             title='<?php echo $this->translate('filter') ?>' border='0'/>
                     </a>
                     <a href="#" class="preselect"
                        onclick="buzzer_preselect_project(<?php echo $project['projectID'] ?>,'<?php echo $this->jsEscape($project['name']) ?>',<?php echo $project['customerID'] ?>,'<?php echo $this->jsEscape($project['customerName']) ?>'); return false;"
                        id="ps<?php echo $project['projectID'] ?>">
                         <img src="<?php echo $this->skin('grfx/preselect_off.png'); ?>" width='13' height='13'
-                             alt='<?php echo $this->kga['lang']['select'] ?>'
-                             title='<?php echo $this->kga['lang']['select'] ?> (ID:<?php echo $project['projectID'] ?>)'
+                             alt='<?php echo $this->translate('select') ?>'
+                             title='<?php echo $this->translate('select') ?> (ID:<?php echo $project['projectID'] ?>)'
                              border='0'/>
                     </a>
                 </td>

--- a/templates/scripts/lists/users.php
+++ b/templates/scripts/lists/users.php
@@ -10,8 +10,8 @@
                     <a href="#"
                        onclick="lists_update_filter('user',<?php echo $user['userID'] ?>); $(this).blur(); return false;"><img
                                 src="<?php echo $this->skin('grfx/filter.png'); ?>" width="13" height="13"
-                                alt="<?php echo $this->kga['lang']['filter'] ?>"
-                                title="<?php echo $this->kga['lang']['filter'] ?>" border="0"/>
+                                alt="<?php echo $this->translate('filter') ?>"
+                                title="<?php echo $this->translate('filter') ?>" border="0"/>
                     </a>
                 </td>
                 <td width="100%" class="clients">


### PR DESCRIPTION
Changes proposed in this pull request:
- use translate method instead of accessing the lang string directly

Reason for this pull request:
- Improve the translation handling while displaying untranslated strings when they are not available
