### PR TITLE
Fix password reset link when KIMAI runs on a custom port

### DIFF
--- a/libraries/Kimai/Auth/Kimai.php
+++ b/libraries/Kimai/Auth/Kimai.php
@@ -85,7 +85,7 @@ class Kimai_Auth_Kimai extends Kimai_Auth_Abstract
         Kimai_Logger::logfile('password reset: ' . $name . ($is_customer ? ' as customer' : ' as user'));
 
         $ssl = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off';
-        $url = ($ssl ? 'https://' : 'http://') . $_SERVER['SERVER_NAME'] . dirname($_SERVER['SCRIPT_NAME']) . '/forgotPassword.php?name=' . urlencode($name) . '&key=' . $passwordResetHash;
+        $url = ($ssl ? 'https://' : 'http://') . $_SERVER['SERVER_NAME'] . ':' . $_SERVER[SERVER_PORT] . dirname($_SERVER['SCRIPT_NAME']) . '/forgotPassword.php?name=' . urlencode($name) . '&key=' . $passwordResetHash;
 
         $message = $kga['lang']['passwordReset']['mailMessage'];
         $message = str_replace('%{URL}', $url, $message);


### PR DESCRIPTION
Added port number to Password reset mail.

FIXES #

Changes proposed in this pull request:
- add Port number to Password reset link

Reason for this pull request:
- I'm running KIMAI on another port. Password reset generates a link without the port so the link won't work
