### PR TITLE
How to build the release zip

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,43 @@
+RELEASE
+=======
+
+Versions up to 1.3.2 provide a file named "kimai_{version}.zip".
+For newer versions, you'll have to create this file manually.
+I've done it using this description on an ubuntu 18.04 system.
+
+Install Various Dependencies
+----------------------------
+
+```
+sudo apt-get install -y ant
+sudo apt-get install -y composer
+sudo apt-get install -y php7.2
+sudo apt-get install -y php7.2-mysql
+sudo apt-get install -y php7.2-xml
+sudo apt-get install -y php7.2-ldap
+sudo apt-get install -y php7.2-mbstring
+```
+
+Checkout Release Tag
+--------------------
+
+```
+cd kimai
+git checkout -b v1.3.5 v1.3.5
+```
+
+Run Composer
+------------
+
+```
+composer  install --no-dev
+```
+
+Build The Zip file
+------------------
+
+```
+ant build
+```
+
+This zip file will be created: /tmp/kimai/kimai_1.3.5.zip

--- a/build.xml
+++ b/build.xml
@@ -50,6 +50,9 @@
 					<exclude name="libraries/phpoffice/phpexcel/unitTests/**"/>
 					<exclude name="libraries/symfony/yaml/Tests/**"/>
 					<exclude name="libraries/tecnickcom/tcpdf/examples/**"/>
+					<exclude name="libraries/zendframework/zendframework1/demos/**"/>
+					<exclude name="libraries/zendframework/zendframework1/documentation/**"/>
+					<exclude name="libraries/zendframework/zendframework1/tests/**"/>
 					<exclude name="temporary/"/>
 					<exclude name="tests/"/>
 				</patternset>


### PR DESCRIPTION
Reason for this pull request:
- I wanted to use version 1.3.5, but didn't find a kimai_1.3.5.zip. So I described how to create it.
