### PR TITLE
Fix issue #1327 and #1326

### DIFF
--- a/core/floaters.php
+++ b/core/floaters.php
@@ -124,7 +124,11 @@ switch ($axAction) {
             $view->assign('id', 0);
         }
 
-        $countries = Zend_Locale::getTranslationList('Territory', $kga['language'], 2);
+        try {
+            $countries = Zend_Locale::getTranslationList('Territory', $kga['language'], 2);
+        } catch (Exception $e) {
+            $countries = Zend_Locale::getTranslationList('Territory');
+        }
         asort($countries);
 
         $view->assign('countries', $countries);

--- a/core/floaters.php
+++ b/core/floaters.php
@@ -106,7 +106,7 @@ switch ($axAction) {
                 $view->assign('id', $id);
             }
         } else {
-            $view->assign('customer', array('timezone' => $kga['timezone']));
+            $view->assign('timezone',  $kga['timezone']);
         }
 
         $view->assign('timezones', timezoneList());
@@ -127,7 +127,7 @@ switch ($axAction) {
         try {
             $countries = Zend_Locale::getTranslationList('Territory', $kga['language'], 2);
         } catch (Exception $e) {
-            $countries = Zend_Locale::getTranslationList('Territory');
+            $countries = Zend_Locale::getTranslationList('Territory', null, 2);
         }
         asort($countries);
 

--- a/core/floaters.php
+++ b/core/floaters.php
@@ -106,7 +106,7 @@ switch ($axAction) {
                 $view->assign('id', $id);
             }
         } else {
-            $view->assign('timezone', $kga['timezone']);
+            $view->assign('customer', array('timezone' => $kga['timezone']));
         }
 
         $view->assign('timezones', timezoneList());

--- a/core/processor.php
+++ b/core/processor.php
@@ -327,7 +327,7 @@ switch ($axAction) {
                 // validate data
                 $errorMessages = [];
 
-                if (count($_REQUEST['projectGroups']) == 0) {
+                if (empty($_REQUEST['projectGroups'])) {
                     $errorMessages['projectGroups'] = $kga['lang']['atLeastOneGroup'];
                 }
 


### PR DESCRIPTION
FIXES #

Changes proposed in this pull request:
- Allows for default timezone to be auto selected when adding new customer

Reason for this pull request:
- Ability for the default timezone to be selected by the system when adding a new customer was broken when related code was refactored to be nested under a sub array called 'customer' rather than each key/value assigned separately
