### PR TITLE
Update en.php to show "City, State" in floater for United States

### DIFF
--- a/core/floaters.php
+++ b/core/floaters.php
@@ -106,7 +106,7 @@ switch ($axAction) {
                 $view->assign('id', $id);
             }
         } else {
-            $view->assign('timezone', $kga['timezone']);
+            $view->assign('customer', array('timezone' => $kga['timezone']));
         }
 
         $view->assign('timezones', timezoneList());

--- a/language/en.php
+++ b/language/en.php
@@ -120,7 +120,7 @@ return [
 
     "street" => "Street",
     "zipcode" => "Zipcode",
-    "city" => "City",
+    "city" => "City, State",
     "country" => "Country",
     "telephon" => "Phone",
     "fax" => "Fax",


### PR DESCRIPTION
FIXES # Not Applicable

Changes proposed in this pull request:

    This is just a simple change that I made so that it is clear to users in the United States to input City, State together (e.g. Fort Myers, FL) in the City field when adding new customers. On the Add Customer floater, it now requests "City, State:" instead of just "City:"

Reason for this pull request:

    When you set up your invoice templates, it pulls city & state together so that the mailing address is properly formatted.
