### PR TITLE
Fix issue #1326

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -50,9 +50,6 @@
 					<exclude name="libraries/phpoffice/phpexcel/unitTests/**"/>
 					<exclude name="libraries/symfony/yaml/Tests/**"/>
 					<exclude name="libraries/tecnickcom/tcpdf/examples/**"/>
-					<exclude name="libraries/zendframework/zendframework1/demos/**"/>
-					<exclude name="libraries/zendframework/zendframework1/documentation/**"/>
-					<exclude name="libraries/zendframework/zendframework1/tests/**"/>
 					<exclude name="temporary/"/>
 					<exclude name="tests/"/>
 				</patternset>

--- a/build.xml
+++ b/build.xml
@@ -50,6 +50,9 @@
 					<exclude name="libraries/phpoffice/phpexcel/unitTests/**"/>
 					<exclude name="libraries/symfony/yaml/Tests/**"/>
 					<exclude name="libraries/tecnickcom/tcpdf/examples/**"/>
+					<exclude name="libraries/zendframework/zendframework1/demos/**"/>
+					<exclude name="libraries/zendframework/zendframework1/documentation/**"/>
+					<exclude name="libraries/zendframework/zendframework1/tests/**"/>
 					<exclude name="temporary/"/>
 					<exclude name="tests/"/>
 				</patternset>

--- a/core/floaters.php
+++ b/core/floaters.php
@@ -124,7 +124,11 @@ switch ($axAction) {
             $view->assign('id', 0);
         }
 
-        $countries = Zend_Locale::getTranslationList('Territory', $kga['language'], 2);
+        try {
+            $countries = Zend_Locale::getTranslationList('Territory', $kga['language'], 2);
+        } catch (Exception $e) {
+            $countries = Zend_Locale::getTranslationList('Territory', null, 2);
+        }
         asort($countries);
 
         $view->assign('countries', $countries);


### PR DESCRIPTION
FIXES #1326 

Changes proposed in this pull request:
- Add a try/catch statement to 'catch' a thrown message from within the Zend Framework library.

Reason for this pull request:
- The Zend Framework does not recognize the 'no-bo' territory. We cannot expect an update from the Zend Framework (https://github.com/zendframework/zf1) as it was EOL 2016-09-28, I have created this work a around to 'catch' the thrown error from within the ZF.