### PR TITLE
fix warnings and deprecation notices when using php 7.4

### DIFF
--- a/includes/func.php
+++ b/includes/func.php
@@ -299,7 +299,7 @@ function createPassword($length)
     $i = 0;
     $password = '';
     while ($i <= $length) {
-        $password .= $chars{mt_rand(0, strlen($chars) - 1)};
+        $password .= $chars[mt_rand(0, strlen($chars) - 1)];
         $i++;
     }
     return $password;

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -2495,7 +2495,7 @@ class Kimai_Database_Mysql
                   FROM ${p}projects AS project
                   JOIN ${p}customers AS customer USING(customerID)
                   JOIN ${p}groups_projects USING(projectID)
-                  WHERE ${p}groups_projects.groupID IN (" . implode($groups, ',') . ")
+                  WHERE ${p}groups_projects.groupID IN (" . implode(',', $groups) . ")
                   AND project.trash=0";
         }
 
@@ -3239,7 +3239,7 @@ class Kimai_Database_Mysql
             $query = "SELECT DISTINCT customerID, name, contact, visible
               FROM ${p}customers
               JOIN ${p}groups_customers AS g_c USING (customerID)
-              WHERE g_c.groupID IN (" . implode($groups, ',') . ")
+              WHERE g_c.groupID IN (" . implode(',', $groups) . ")
                 AND trash=0
               ORDER BY visible DESC, name;";
         }
@@ -3288,7 +3288,7 @@ class Kimai_Database_Mysql
             $query = "SELECT DISTINCT activityID, name, visible
               FROM ${p}activities
               JOIN ${p}groups_activities AS g_a USING(activityID)
-              WHERE g_a.groupID IN (" . implode($groups, ',') . ")
+              WHERE g_a.groupID IN (" . implode(',', $groups) . ")
                 AND trash=0
               ORDER BY visible DESC, name;";
         }
@@ -3348,7 +3348,7 @@ class Kimai_Database_Mysql
             FROM ${p}activities AS activity
             JOIN ${p}groups_activities USING(activityID)
             LEFT JOIN ${p}projects_activities p_a USING(activityID)
-            WHERE `${p}groups_activities`.`groupID`  IN (" . implode($groups, ',') . ")
+            WHERE `${p}groups_activities`.`groupID`  IN (" . implode(',', $groups) . ")
               AND activity.trash=0
               AND (projectID = $projectID OR projectID IS NULL)
             ORDER BY visible DESC, name;";

--- a/libraries/Kimai/Database/Mysql.php
+++ b/libraries/Kimai/Database/Mysql.php
@@ -2972,7 +2972,7 @@ class Kimai_Database_Mysql
                 case 'roundMinutes':
                 case 'roundSeconds':
                     $config->getSettings()->set($key, $value);
-                    // break is not here on purpose!
+                    // no break
 
                 case 'adminmail':
                 case 'loginTries':

--- a/libraries/phpclasses/ultimatemysql/mysql.class.php
+++ b/libraries/phpclasses/ultimatemysql/mysql.class.php
@@ -1588,9 +1588,6 @@ class MySQL
 				if (strlen($value) == 0) {
 					$return_value = "NULL";
 				} else {
-					if (version_compare(PHP_VERSION, "5.4.0", '<') && get_magic_quotes_gpc()) {
-						$value = stripslashes($value);
-					}
 					$return_value = "'" . str_replace("'", "''", $value) . "'";
 				}
 				break;

--- a/libraries/phpclasses/ultimatemysql/mysql.class.php
+++ b/libraries/phpclasses/ultimatemysql/mysql.class.php
@@ -1588,7 +1588,7 @@ class MySQL
 				if (strlen($value) == 0) {
 					$return_value = "NULL";
 				} else {
-					if (get_magic_quotes_gpc()) {
+					if (version_compare(PHP_VERSION, "5.4.0", '<') && get_magic_quotes_gpc()) {
 						$value = stripslashes($value);
 					}
 					$return_value = "'" . str_replace("'", "''", $value) . "'";


### PR DESCRIPTION
* replaces `while each` loops with `foreach` loops
* fixes order of `$glue` and `$pieces` of `implode` function calls (<https://www.php.net/manual/de/function.implode.php>)
* fixes accessing chars of a string (using square instead of curly braces)
* use `get_magic_quotes_gpc` only if PHP version is less than 5.4.0 (see <https://www.php.net/manual/de/function.get-magic-quotes-gpc.php>)